### PR TITLE
Feat/remote printer

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -69,6 +69,10 @@ message OSLogin {
   string password = 2;
 }
 
+message ClientFeature {
+  bool printer = 1;
+}
+
 message LoginRequest {
   string username = 1;
   bytes password = 2;
@@ -86,6 +90,7 @@ message LoginRequest {
   OSLogin os_login = 12;
   string my_platform = 13;
   bytes hwid = 14;
+  string platform_additions = 16;
 }
 
 message Auth2FA {
@@ -843,6 +848,40 @@ message VoiceCallResponse {
   int64 ack_timestamp = 3;
 }
 
+message PrinterRequest {
+  int32 id = 1;
+}
+
+message PrinterResponse {
+  int32 id = 1;
+  bool accepted = 2;
+}
+
+message PrinterBlock {
+  int32 id = 1;
+  bytes data = 2;
+  bool compressed = 3;
+}
+
+message PrinterDone {
+  int32 id = 1;
+}
+
+message PrinterError {
+  int32 id = 1;
+  string error = 2;
+}
+
+message Printer {
+  oneof union {
+    PrinterRequest printer_request = 1;
+    PrinterResponse printer_response = 2;
+    PrinterBlock printer_block = 3;
+    PrinterDone printer_done = 4;
+    PrinterError printer_error = 5;
+  }
+}
+
 message Message {
   oneof union {
     SignedId signed_id = 3;
@@ -871,5 +910,6 @@ message Message {
     PointerDeviceEvent pointer_device_event = 26;
     Auth2FA auth_2fa = 27;
     MultiClipboards multi_clipboards = 28;
+    Printer printer = 29;
   }
 }

--- a/protos/message.proto
+++ b/protos/message.proto
@@ -69,10 +69,6 @@ message OSLogin {
   string password = 2;
 }
 
-message ClientFeature {
-  bool printer = 1;
-}
-
 message LoginRequest {
   string username = 1;
   bytes password = 2;
@@ -457,6 +453,12 @@ message FileTransferSendRequest {
   string path = 2;
   bool include_hidden = 3;
   int32 file_num = 4;
+
+  enum FileType {
+    Generic = 0;
+    Printer = 1;
+  }
+  FileType file_type = 5;
 }
 
 message FileTransferSendConfirmRequest {
@@ -848,40 +850,6 @@ message VoiceCallResponse {
   int64 ack_timestamp = 3;
 }
 
-message PrinterRequest {
-  int32 id = 1;
-}
-
-message PrinterResponse {
-  int32 id = 1;
-  bool accepted = 2;
-}
-
-message PrinterBlock {
-  int32 id = 1;
-  bytes data = 2;
-  bool compressed = 3;
-}
-
-message PrinterDone {
-  int32 id = 1;
-}
-
-message PrinterError {
-  int32 id = 1;
-  string error = 2;
-}
-
-message Printer {
-  oneof union {
-    PrinterRequest printer_request = 1;
-    PrinterResponse printer_response = 2;
-    PrinterBlock printer_block = 3;
-    PrinterDone printer_done = 4;
-    PrinterError printer_error = 5;
-  }
-}
-
 message Message {
   oneof union {
     SignedId signed_id = 3;
@@ -910,6 +878,5 @@ message Message {
     PointerDeviceEvent pointer_device_event = 26;
     Auth2FA auth_2fa = 27;
     MultiClipboards multi_clipboards = 28;
-    Printer printer = 29;
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2378,6 +2378,10 @@ pub mod keys {
     pub const OPTION_FLUTTER_CURRENT_AB_NAME: &str = "current-ab-name";
     pub const OPTION_ALLOW_REMOTE_CM_MODIFICATION: &str = "allow-remote-cm-modification";
 
+    pub const OPTION_PRINTER_INCOMING_JOB_ACTION: &str = "printer-incomming-job-action";
+    pub const OPTION_PRINTER_ALLOW_AUTO_PRINT: &str = "allow-printer-auto-print";
+    pub const OPTION_PRINTER_SELECTED_NAME: &str = "printer-selected-name";
+
     // android floating window options
     pub const OPTION_DISABLE_FLOATING_WINDOW: &str = "disable-floating-window";
     pub const OPTION_FLOATING_WINDOW_SIZE: &str = "floating-window-size";

--- a/src/config.rs
+++ b/src/config.rs
@@ -2277,6 +2277,7 @@ pub mod keys {
     pub const OPTION_ZOOM_CURSOR: &str = "zoom-cursor";
     pub const OPTION_SHOW_QUALITY_MONITOR: &str = "show_quality_monitor";
     pub const OPTION_DISABLE_AUDIO: &str = "disable_audio";
+    pub const OPTION_ENABLE_REMOTE_PRINTER: &str = "enable-remote-printer";
     pub const OPTION_ENABLE_FILE_COPY_PASTE: &str = "enable-file-copy-paste";
     pub const OPTION_DISABLE_CLIPBOARD: &str = "disable_clipboard";
     pub const OPTION_LOCK_AFTER_SESSION_END: &str = "lock_after_session_end";


### PR DESCRIPTION
For remote printer feature.

1. Move file transfer job ID manager into the Rust side, so that job IDs are globally unique. Current version is in the Flutter and the Sciter sides. `get_next_job_id()` and `update_next_job_id()`.
2. Introduce the job type. The functions are changed. Compilation with this commit and current master commit in RustDesk will fail.
