### PR TITLE
Fixes related to systemd manager class session

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -175,7 +175,7 @@ fn _get_values_of_seat0(indices: &[usize], ignore_gdm_wayland: bool) -> Vec<Stri
                             continue;
                         }
                     }
-                    if d == "tty" {
+                    if d == "tty" || d == "unspecified" {
                         continue;
                     }
                     return line_values(indices, line);

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -104,7 +104,7 @@ pub fn get_display_server_of_session(session: &str) -> String {
     } else {
         "".to_owned()
     };
-    if display_server.is_empty() || display_server == "tty" {
+    if display_server.is_empty() || display_server == "tty" || display_server == "unspecified" {
         if let Ok(sestype) = std::env::var("XDG_SESSION_TYPE") {
             if !sestype.is_empty() {
                 return sestype.to_lowercase();


### PR DESCRIPTION
Let me know if there is a reason we do not want to skip `Type=unspecified` session (regardless of whether their `Class=` is `manager`). As far as I can see, apparently what we are trying to do here is to find a session that we can infer its "real" type (i.e. running X or Wayland) through its `Type=`, so it seems to me that anything that is obviously unhelpful can be safely skipped.

An alternative approach would be to check the `Class=` of the picked session, although it's somewhat less safe in some corner cases (that may not really exist), and takes an addition `loginctl` run: https://github.com/tomty89/hbb_common/commit/cb0f8eb1c73d0e4e92225856a893742f8a665aaf.