### PR TITLE
fix: linux, dm user

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -87,7 +87,7 @@ pub fn is_kde() -> bool {
 
 #[inline]
 pub fn is_gdm_user(username: &str) -> bool {
-    username == "gdm"
+    username == "gdm" || username == "sddm"
     // || username == "lightgdm"
 }
 


### PR DESCRIPTION
`is_gdm_user()` is mainly used to check if is the Display Manager user.

Both `gdm` and `sddm` are commonly Display Manager users.
