### PR TITLE
feat: terminal, restore sessions

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -907,6 +907,7 @@ message TerminalOpened {
   string message = 3;
   uint32 pid = 4;
   string service_id = 5;  // Service ID for persistent sessions
+  repeated int32 persistent_sessions = 6; // Used to restore the persistent sessions.
 }
 
 message TerminalClosed {


### PR DESCRIPTION
Use `persistent_sessions` to restore previous persistent sessions in the response message `TerminalOpened`.