### PR TITLE
feat: file transfer, resume

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -437,6 +437,7 @@ message FileTransferDigest {
   uint64 file_size = 4;
   bool is_upload = 5;
   bool is_identical = 6;
+  uint64 transferred_size = 7; // for resume transfer, indicates the size of the file already transferred
 }
 
 message FileTransferBlock {


### PR DESCRIPTION
File transfer, resume, starting from offset.

## Feats

Resume

1. Add `transfered_size` as the offset in `FileTransferDigest` for each file.
2. Save digest (`size` and `modified`) as `.digest` for current transferring file.
3. Call `set_stream_offset()` if `offset > 0` in `confirm()`.
4. Check the `.download` and `.digest` files first in `is_write_need_confirmation()`. If both files exist and the digest is identical, start transferring from the size of `.download` file.

### Breaks

Change `pub fn confirm()` to `async fn confirm()`.

## Changes

Execute file transfer jobs one by one.  https://github.com/rustdesk/rustdesk/discussions/12186

Add the following lines in `handle_read_jobs()`.

```rust
for job in jobs.iter_mut() {
       ... // Read and transfer
      // Break to handle jobs one by one.
      break;
}
```
