### PR TITLE
fix: file transfer, resume

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1203,13 +1203,14 @@ pub enum DigestCheckResult {
 
 #[inline]
 pub fn is_write_need_confirmation(
+    is_support_resume: bool,
     file_path: &str,
     digest: &FileTransferDigest,
 ) -> ResultType<DigestCheckResult> {
     let path = Path::new(file_path);
     let digest_file = format!("{}.digest", file_path);
     let download_file = format!("{}.download", file_path);
-    if Path::new(&digest_file).exists() && Path::new(&download_file).exists() {
+    if is_support_resume && Path::new(&digest_file).exists() && Path::new(&download_file).exists() {
         // If the digest file exists, it means the file was transferred before.
         // We can use the digest file to check whether the file is the same.
         if let Ok(content) = std::fs::read_to_string(digest_file) {


### PR DESCRIPTION
Check `is_support_resume` in `is_write_need_confirmation()`.

We only need to check `.digest` and `.download` files if both sides support file transfer resumability.
