### PR TITLE
feat: file transfer, digest flag, is_resume

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -437,7 +437,11 @@ message FileTransferDigest {
   uint64 file_size = 4;
   bool is_upload = 5;
   bool is_identical = 6;
-  uint64 transferred_size = 7; // for resume transfer, indicates the size of the file already transferred
+  uint64 transferred_size = 7; // For resume. Indicates the size of the file already transferred
+  bool is_resume = 8;          // For resume. Indicates if the transfer is a resume.
+                               // `is_resume` can let the controlled side know whether to check the `.digest` file.
+                               // When `is_resume` is false, `.digest` exists, the same file does not exist,
+                               // the controlled side should not check `.digest`, it should confirm with a new transfer request.
 }
 
 message FileTransferBlock {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -806,6 +806,7 @@ impl TransferJob {
             file_num: self.file_num,
             last_modified,
             file_size: meta.len(),
+            is_resume: self.is_resume,
             ..Default::default()
         });
         msg.set_file_response(resp);
@@ -1203,14 +1204,14 @@ pub enum DigestCheckResult {
 
 #[inline]
 pub fn is_write_need_confirmation(
-    is_support_resume: bool,
+    is_resume: bool,
     file_path: &str,
     digest: &FileTransferDigest,
 ) -> ResultType<DigestCheckResult> {
     let path = Path::new(file_path);
     let digest_file = format!("{}.digest", file_path);
     let download_file = format!("{}.download", file_path);
-    if is_support_resume && Path::new(&digest_file).exists() && Path::new(&download_file).exists() {
+    if is_resume && Path::new(&digest_file).exists() && Path::new(&download_file).exists() {
         // If the digest file exists, it means the file was transferred before.
         // We can use the digest file to check whether the file is the same.
         if let Ok(content) = std::fs::read_to_string(digest_file) {


### PR DESCRIPTION
Add `is_resume` in `FileTransferDigest`, then the controlled side can know if it should check `.digest` file.
