### PR TITLE
feat: opt, show my cursor

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -693,6 +693,7 @@ message OptionMessage {
   BoolOption follow_remote_window = 16;
   BoolOption disable_camera = 17;
   BoolOption terminal_persistent = 18;
+  BoolOption show_my_cursor = 19;
 }
 
 message TestDelay {

--- a/src/config.rs
+++ b/src/config.rs
@@ -296,6 +296,8 @@ pub struct PeerConfig {
     #[serde(flatten)]
     pub view_only: ViewOnly,
     #[serde(flatten)]
+    pub show_my_cursor: ShowMyCursor,
+    #[serde(flatten)]
     pub sync_init_clipboard: SyncInitClipboard,
     // Mouse wheel or touchpad scroll mode
     #[serde(
@@ -372,6 +374,7 @@ impl Default for PeerConfig {
             follow_remote_window: Default::default(),
             keyboard_mode: Default::default(),
             view_only: Default::default(),
+            show_my_cursor: Default::default(),
             reverse_mouse_wheel: Self::default_reverse_mouse_wheel(),
             displays_as_individual_windows: Self::default_displays_as_individual_windows(),
             use_all_my_displays_for_the_remote_session:
@@ -1678,6 +1681,13 @@ serde_field_bool!(
     "view_only",
     default_view_only,
     "ViewOnly::default_view_only"
+);
+
+serde_field_bool!(
+    ShowMyCursor,
+    "show_my_cursor",
+    default_show_my_cursor,
+    "ShowMyCursor::default_show_my_cursor"
 );
 
 serde_field_bool!(


### PR DESCRIPTION
Only Windows as the controlled side is supported.

https://github.com/user-attachments/assets/6d9b2410-5908-488d-a974-1e3df2ac5a1f

