### PR TITLE
remove can't save option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1024,6 +1024,10 @@ impl Config {
 
     pub fn set_option(k: String, v: String) {
         if !is_option_can_save(&OVERWRITE_SETTINGS, &k, &DEFAULT_SETTINGS, &v) {
+            let mut config = CONFIG2.write().unwrap();
+            if config.options.remove(&k).is_some() {
+                config.store();
+            }
             return;
         }
         let mut config = CONFIG2.write().unwrap();
@@ -1800,6 +1804,10 @@ impl LocalConfig {
 
     pub fn set_option(k: String, v: String) {
         if !is_option_can_save(&OVERWRITE_LOCAL_SETTINGS, &k, &DEFAULT_LOCAL_SETTINGS, &v) {
+            let mut config = LOCAL_CONFIG.write().unwrap();
+            if config.options.remove(&k).is_some() {
+                config.store();
+            }
             return;
         }
         let mut config = LOCAL_CONFIG.write().unwrap();
@@ -1960,6 +1968,9 @@ impl UserDefaultConfig {
             &DEFAULT_DISPLAY_SETTINGS,
             &value,
         ) {
+            if self.options.remove(&key).is_some() {
+                self.store();
+            }
             return;
         }
         if value.is_empty() {


### PR DESCRIPTION
When `is_option_can_save` returns false, remove this key from options.

`is_option_can_save` return false because: 
* If the key exists in override options, there is no need to save this key, and remove the config option is ok.
* If the key-value pair in default options is equal, there is no need to save this key-value pair, but need to remove the old key-value pair if exist.

https://github.com/user-attachments/assets/65bbfa3e-0e07-4cc7-8a77-6b86ed133480

https://github.com/user-attachments/assets/7d15d45b-7cfd-41f4-87d7-d48987a2d91b

