### PR TITLE
refact: option, touch mode, move to local

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1581,7 +1581,6 @@ impl PeerConfig {
             keys::OPTION_CODEC_PREFERENCE,
             keys::OPTION_CUSTOM_FPS,
             keys::OPTION_ZOOM_CURSOR,
-            keys::OPTION_TOUCH_MODE,
             keys::OPTION_I444,
             keys::OPTION_SWAP_LEFT_RIGHT_MOUSE,
             keys::OPTION_COLLAPSE_TOOLBAR,
@@ -2502,6 +2501,11 @@ pub mod keys {
     pub const OPTION_AV1_TEST: &str = "av1-test";
     pub const OPTION_TRACKPAD_SPEED: &str = "trackpad-speed";
     pub const OPTION_REGISTER_DEVICE: &str = "register-device";
+    pub const OPTION_RELAY_SERVER: &str = "relay-server";
+    pub const OPTION_SHOW_VIRTUAL_MOUSE: &str = "show-virtual-mouse";
+    // joystick is the virtual mouse.
+    // So `OPTION_SHOW_VIRTUAL_MOUSE` should also be set if `OPTION_SHOW_JOYSTICK` is set.
+    pub const OPTION_SHOW_JOYSTICK: &str = "show-joystick";
 
     // built-in options
     pub const OPTION_DISPLAY_NAME: &str = "display-name";
@@ -2633,6 +2637,9 @@ pub mod keys {
         OPTION_VIDEO_SAVE_DIRECTORY,
         OPTION_ENABLE_UDP_PUNCH,
         OPTION_ENABLE_IPV6_PUNCH,
+        OPTION_TOUCH_MODE,
+        OPTION_SHOW_VIRTUAL_MOUSE,
+        OPTION_SHOW_JOYSTICK,
     ];
     // DEFAULT_SETTINGS, OVERWRITE_SETTINGS
     pub const KEYS_SETTINGS: &[&str] = &[
@@ -2678,6 +2685,7 @@ pub mod keys {
         OPTION_ENABLE_DIRECTX_CAPTURE,
         OPTION_ENABLE_ANDROID_SOFTWARE_ENCODING_HALF_SCALE,
         OPTION_ENABLE_TRUSTED_DEVICES,
+        OPTION_RELAY_SERVER,
     ];
 
     // BUILDIN_SETTINGS

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::keys::OPTION_RELAY_SERVER,
     config::{use_ws, Config, Socks5Server, RELAY_PORT, RENDEZVOUS_PORT},
     protobuf::Message,
     socket_client::split_host_port,
@@ -214,7 +215,7 @@ pub fn check_ws(endpoint: &str) -> String {
     };
 
     let custom_rendezvous_server = Config::get_rendezvous_server();
-    let relay_server = Config::get_option("relay-server");
+    let relay_server = Config::get_option(OPTION_RELAY_SERVER);
     let rendezvous_port = split_host_port(&custom_rendezvous_server)
         .map(|(_, p)| p)
         .unwrap_or(RENDEZVOUS_PORT);


### PR DESCRIPTION
1. Move `touch-mode` from session configuration to local configuration.

Remove `touch-mode` from `fn default_options()`.

2. Add `relay-server` in `KEYS_SETTINGS`.

3. Add `touch-mode`, `show-virtual-mouse-touch-mode` and `show-virtual-mouse-mouse-mode` in `KEYS_LOCAL_SETTINGS`.