### PR TITLE
fix: file transfer, confirm, remember

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -701,18 +701,17 @@ impl TransferJob {
         }
     }
 
-    pub async fn read(&mut self, stream: &mut Stream) -> ResultType<Option<FileTransferBlock>> {
+    async fn init_data_stream(&mut self, stream: &mut crate::Stream) -> ResultType<()> {
         let file_num = self.file_num as usize;
-        let name: &str;
         match &mut self.data_source {
             DataSource::FilePath(p) => {
                 if file_num >= self.files.len() {
+                    // job done
                     self.data_stream.take();
-                    return Ok(None);
+                    return Ok(());
                 };
-                name = &self.files[file_num].name;
                 if self.data_stream.is_none() {
-                    match File::open(Self::join(p, name)).await {
+                    match File::open(Self::join(p, &self.files[file_num].name)).await {
                         Ok(file) => {
                             self.data_stream = Some(DataStream::FileStream(file));
                             self.file_confirmed = false;
@@ -728,7 +727,6 @@ impl TransferJob {
                 }
             }
             DataSource::MemoryCursor(c) => {
-                name = "";
                 if self.data_stream.is_none() {
                     let mut t = std::io::Cursor::new(Vec::new());
                     std::mem::swap(&mut t, c);
@@ -742,7 +740,30 @@ impl TransferJob {
                     self.send_current_digest(stream).await?;
                     self.set_file_is_waiting(true);
                 }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn read(&mut self) -> ResultType<Option<FileTransferBlock>> {
+        if self.r#type == JobType::Generic {
+            if self.enable_overwrite_detection && !self.file_confirmed() {
                 return Ok(None);
+            }
+        }
+
+        let file_num = self.file_num as usize;
+        let name: &str;
+        match &mut self.data_source {
+            DataSource::FilePath(..) => {
+                if file_num >= self.files.len() {
+                    self.data_stream.take();
+                    return Ok(None);
+                };
+                name = &self.files[file_num].name;
+            }
+            DataSource::MemoryCursor(..) => {
+                name = "";
             }
         }
         const BUF_SIZE: usize = 128 * 1024;
@@ -1112,17 +1133,30 @@ pub fn get_job_immutable(id: i32, jobs: &[TransferJob]) -> Option<&TransferJob> 
     jobs.iter().find(|x| x.id() == id)
 }
 
+async fn init_jobs(jobs: &mut Vec<TransferJob>, stream: &mut crate::Stream) -> ResultType<()> {
+    for job in jobs.iter_mut() {
+        if let Err(err) = job.init_data_stream(stream).await {
+            stream
+                .send(&new_error(job.id(), err, job.file_num()))
+                .await?;
+        }
+    }
+    Ok(())
+}
+
 pub async fn handle_read_jobs(
     jobs: &mut Vec<TransferJob>,
     stream: &mut crate::Stream,
 ) -> ResultType<String> {
+    init_jobs(jobs, stream).await?;
+
     let mut job_log = Default::default();
     let mut finished = Vec::new();
     for job in jobs.iter_mut() {
         if job.is_last_job {
             continue;
         }
-        match job.read(stream).await {
+        match job.read().await {
             Err(err) => {
                 stream
                     .send(&new_error(job.id(), err, job.file_num()))


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/13082

## Desc

This line breaks concurrent file override confirmations.  https://github.com/rustdesk/hbb_common/blob/7ea868612dfee7954facb9a7857d65ef875076eb/src/fs.rs#L1152 

This issue arises from a timing constraint: the controlling side requires that file override confirmations be processed within a single event loop cycle (a short timeframe). `overrideConfirm` must remain true throughout this period to ensure proper handling.

However, if a new confirmation arrives after the previous ones are processed, `overrideConfirm` gets set to null, which breaks the concurrent confirmation mechanism.

Relevant code references:

Event loop timeout logic:
https://github.com/rustdesk/rustdesk/blob/d110118961d2fb7c6084d3c9bef4d0198bc3137d/flutter/lib/utils/event_loop.dart#L63

overrideConfirm being set to null:
https://github.com/rustdesk/rustdesk/blob/d110118961d2fb7c6084d3c9bef4d0198bc3137d/flutter/lib/models/file_model.dart#L1748

### Changes

Split `TransferJob.read()` into `TransferJob.init_data_stream()` and `TransferJob.read()`.

**init_data_stream()**: Init the datastream and send the override confirmation. This function can be called concurrently.
**read()**: Read the datastream one by one.

## Preview



https://github.com/user-attachments/assets/7368ef5c-ea79-4577-b4d8-254a613e55b5



## Tests

- [x] This commit <-> 1.4.2
- [x] This commit <-> 1.4.1

## Issue

> the controlling side requires that file override confirmations be processed within a single event loop cycle (a short timeframe)

It is not a good implementation.

Example, both sides `1.4.1`:

https://github.com/user-attachments/assets/c0a4fc41-3b0a-4c73-b03d-5c05b3a1880c


I am unsure whether to implement better controls or stick with the current implementation.
