### PR TITLE
Remove useless command calls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -440,14 +440,8 @@ fn patch(path: PathBuf) -> PathBuf {
         #[cfg(target_os = "linux")]
         {
             if _tmp == "/root" {
-                if let Ok(user) = crate::platform::linux::run_cmds_trim_newline("whoami") {
-                    if user != "root" {
-                        let cmd = format!("getent passwd '{}' | awk -F':' '{{print $6}}'", user);
-                        if let Ok(output) = crate::platform::linux::run_cmds_trim_newline(&cmd) {
-                            return output.into();
-                        }
-                        return format!("/home/{user}").into();
-                    }
+                if let Some(home_dir) = std::env::home_dir() {
+                    return home_dir;
                 }
             }
         }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -37,8 +37,6 @@ lazy_static::lazy_static! {
 // ...
 lazy_static::lazy_static! {
     pub static ref CMD_LOGINCTL: String = find_cmd_path("loginctl");
-    pub static ref CMD_PS: String = find_cmd_path("ps");
-    pub static ref CMD_SH: String = find_cmd_path("sh");
 }
 
 pub const DISPLAY_SERVER_WAYLAND: &str = "wayland";
@@ -106,9 +104,9 @@ pub fn is_kde() -> bool {
 // Don't use `hbb_common::platform::linux::is_kde()` here.
 // It's not correct in the server process.
 pub fn is_kde_session() -> bool {
-    std::process::Command::new(CMD_SH.as_str())
-        .arg("-c")
-        .arg("pgrep -f kded[0-9]+")
+    Command::new("pgrep")
+        .arg("-f")
+        .arg("kded[0-9]+")
         .stdout(std::process::Stdio::piped())
         .output()
         .map(|o| !o.stdout.is_empty())

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -146,7 +146,7 @@ pub fn get_display_server() -> String {
             session = sid;
         }
         if session.is_empty() {
-            session = run_cmds("cat /proc/self/sessionid").unwrap_or_default();
+            session = std::fs::read_to_string("/proc/self/sessionid").unwrap_or_default();
             if session == INVALID_SESSION {
                 session = "".to_owned();
             }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -281,24 +281,11 @@ pub fn is_session_locked(sid: &str) -> bool {
 }
 
 // **Note** that the return value here, the last character is '\n'.
-// Use `run_cmds_trim_newline()` if you want to remove '\n' at the end.
 pub fn run_cmds(cmds: &str) -> ResultType<String> {
     let output = std::process::Command::new(CMD_SH.as_str())
         .args(vec!["-c", cmds])
         .output()?;
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-pub fn run_cmds_trim_newline(cmds: &str) -> ResultType<String> {
-    let output = std::process::Command::new(CMD_SH.as_str())
-        .args(vec!["-c", cmds])
-        .output()?;
-    let out = String::from_utf8_lossy(&output.stdout);
-    Ok(if out.ends_with('\n') {
-        out[..out.len() - 1].to_string()
-    } else {
-        out.to_string()
-    })
 }
 
 fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
@@ -440,19 +427,4 @@ pub fn get_wayland_displays() -> ResultType<Vec<WaylandDisplayInfo>> {
     }
 
     Ok(display_infos)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_run_cmds_trim_newline() {
-        assert_eq!(run_cmds_trim_newline("echo -n 123").unwrap(), "123");
-        assert_eq!(run_cmds_trim_newline("echo 123").unwrap(), "123");
-        assert_eq!(
-            run_cmds_trim_newline("whoami").unwrap() + "\n",
-            run_cmds("whoami").unwrap()
-        );
-    }
 }


### PR DESCRIPTION
[Someone on lobste.rs](https://lobste.rs/s/njfvjb/rustdesk_with_tailscale_on_arch_linux#c_5dyag0) found those out two years ago, but besides complaining nobody fixed them… So here I am, I’ve only fixed the most glaring issues, I plan on replacing the remaining loginctl calls with [zbus](https://docs.rs/zbus) and then [this issue](https://github.com/rustdesk/rustdesk/discussions/11959) can be closed as fixed.