### PR TITLE
Security fix

### DIFF
--- a/protos/rendezvous.proto
+++ b/protos/rendezvous.proto
@@ -4,6 +4,7 @@ package hbb;
 message RegisterPeer {
   string id = 1;
   int32 serial = 2;
+  string licence_key = 3;
 }
 
 enum ConnType {
@@ -61,6 +62,7 @@ message PunchHole {
 
 message TestNatRequest {
   int32 serial = 1;
+  string licence_key = 2;
 }
 
 // per my test, uint/int has no difference in encoding, int not good for negative, use sint for negative
@@ -91,6 +93,7 @@ message RegisterPk {
   bytes pk = 3;
   string old_id = 4;
   bool no_register_device = 5;
+  string licence_key = 6;
 }
 
 message RegisterPkResponse {
@@ -102,6 +105,8 @@ message RegisterPkResponse {
     INVALID_ID_FORMAT = 5;
     NOT_SUPPORT = 6;
     SERVER_ERROR = 7;
+    LICENSE_MISMATCH = 8;
+    PEER_LIMIT_REACHED = 9;
   }
   Result result = 1;
   int32 keep_alive = 2;
@@ -196,6 +201,7 @@ message PeerDiscovery {
 message OnlineRequest {
   string id = 1;
   repeated string peers = 2;
+  string licence_key = 3;
 }
 
 message OnlineResponse {

--- a/src/bytes_codec.rs
+++ b/src/bytes_codec.rs
@@ -2,6 +2,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
+const DEFAULT_MAX_PACKET_LENGTH: usize = 64 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy)]
 pub struct BytesCodec {
     state: DecodeState,
@@ -26,7 +28,7 @@ impl BytesCodec {
         Self {
             state: DecodeState::Head,
             raw: false,
-            max_packet_length: usize::MAX,
+            max_packet_length: DEFAULT_MAX_PACKET_LENGTH,
         }
     }
 
@@ -137,6 +139,25 @@ impl Encoder<Bytes> for BytesCodec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn encode_head_only(len: usize) -> BytesMut {
+        let mut buf = BytesMut::new();
+        if len <= 0x3F {
+            buf.put_u8((len << 2) as u8);
+        } else if len <= 0x3FFF {
+            buf.put_u16_le((len << 2) as u16 | 0x1);
+        } else if len <= 0x3FFFFF {
+            let h = (len << 2) as u32 | 0x2;
+            buf.put_u16_le((h & 0xFFFF) as u16);
+            buf.put_u8((h >> 16) as u8);
+        } else if len <= 0x3FFFFFFF {
+            buf.put_u32_le((len << 2) as u32 | 0x3);
+        } else {
+            panic!("test packet length overflow");
+        }
+        buf
+    }
+
     #[test]
     fn test_codec1() {
         let mut codec = BytesCodec::new();
@@ -276,5 +297,20 @@ mod tests {
         } else {
             panic!();
         }
+    }
+
+    #[test]
+    fn test_codec_rejects_packet_above_default_limit() {
+        let mut codec = BytesCodec::new();
+        let mut buf = encode_head_only(DEFAULT_MAX_PACKET_LENGTH + 1);
+        assert!(codec.decode(&mut buf).is_err());
+    }
+
+    #[test]
+    fn test_codec_rejects_packet_above_custom_limit() {
+        let mut codec = BytesCodec::new();
+        codec.set_max_packet_length(16);
+        let mut buf = encode_head_only(17);
+        assert!(codec.decode(&mut buf).is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1252,8 +1252,19 @@ impl Config {
 
     pub fn set_options(mut v: HashMap<String, String>) {
         Self::purify_options(&mut v);
+        let previous_options = CONFIG2.read().unwrap().options.clone();
+        let mut rejected_keys = Vec::new();
         for (key, value) in v.iter_mut() {
-            Self::maybe_encrypt_option_value(key, value);
+            if !Self::maybe_encrypt_option_value(key, value) {
+                rejected_keys.push(key.clone());
+            }
+        }
+        for key in rejected_keys {
+            if let Some(old) = previous_options.get(&key) {
+                v.insert(key, old.clone());
+            } else {
+                v.remove(&key);
+            }
         }
         let mut config = CONFIG2.write().unwrap();
         if config.options == v {
@@ -1289,7 +1300,9 @@ impl Config {
         }
         let mut config = CONFIG2.write().unwrap();
         let mut stored = v;
-        Self::maybe_encrypt_option_value(&k, &mut stored);
+        if !Self::maybe_encrypt_option_value(&k, &mut stored) {
+            return;
+        }
         let v2 = if stored.is_empty() {
             None
         } else {
@@ -1320,11 +1333,30 @@ impl Config {
         *v = plain;
     }
 
-    fn maybe_encrypt_option_value(k: &str, v: &mut String) {
+    fn maybe_encrypt_option_value(k: &str, v: &mut String) -> bool {
         if !Self::is_encrypted_option(k) || v.is_empty() {
-            return;
+            return true;
         }
-        *v = encrypt_str_or_original(v, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+        let plain_len = v.chars().count();
+        if plain_len > ENCRYPT_MAX_LEN {
+            log::error!(
+                "Refusing to store encrypted option {} because it exceeds ENCRYPT_MAX_LEN ({} > {})",
+                k,
+                plain_len,
+                ENCRYPT_MAX_LEN
+            );
+            return false;
+        }
+        let encrypted = encrypt_str_or_original(v, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+        if encrypted.is_empty() {
+            log::error!(
+                "Failed to encrypt option {} before storing it; keeping the previous value",
+                k
+            );
+            return false;
+        }
+        *v = encrypted;
+        true
     }
 
     pub fn update_id() {
@@ -3598,6 +3630,48 @@ mod tests {
         Config::set_bootstrap_config_for_test(saved_bootstrap);
         *EXE_RENDEZVOUS_SERVER.write().unwrap() = saved_exe;
         *PROD_RENDEZVOUS_SERVER.write().unwrap() = saved_prod;
+        *CONFIG2.write().unwrap() = saved_config2;
+    }
+
+    #[test]
+    fn test_encrypted_option_rejects_oversized_value_in_set_option() {
+        let saved_config2 = CONFIG2.read().unwrap().clone();
+        let key = keys::OPTION_DIRECT_ACCESS_PAIRING_PASSPHRASE.to_owned();
+        let original = "secret-passphrase".to_owned();
+
+        {
+            let mut config2 = CONFIG2.write().unwrap();
+            config2.options.clear();
+        }
+
+        Config::set_option(key.clone(), original.clone());
+        assert_eq!(Config::get_option(&key), original);
+
+        Config::set_option(key.clone(), "x".repeat(ENCRYPT_MAX_LEN + 1));
+        assert_eq!(Config::get_option(&key), original);
+
+        *CONFIG2.write().unwrap() = saved_config2;
+    }
+
+    #[test]
+    fn test_encrypted_option_rejects_oversized_value_in_set_options() {
+        let saved_config2 = CONFIG2.read().unwrap().clone();
+        let key = keys::OPTION_PEER_PAIRING_PASSPHRASE.to_owned();
+        let original = "peer-secret-passphrase".to_owned();
+
+        {
+            let mut config2 = CONFIG2.write().unwrap();
+            config2.options.clear();
+        }
+
+        Config::set_option(key.clone(), original.clone());
+        assert_eq!(Config::get_option(&key), original);
+
+        let mut options = HashMap::new();
+        options.insert(key.clone(), "x".repeat(ENCRYPT_MAX_LEN + 1));
+        Config::set_options(options);
+        assert_eq!(Config::get_option(&key), original);
+
         *CONFIG2.write().unwrap() = saved_config2;
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,7 @@ type KeyPair = (Vec<u8>, Vec<u8>);
 lazy_static::lazy_static! {
     static ref CONFIG: RwLock<Config> = RwLock::new(Config::load());
     static ref CONFIG2: RwLock<Config2> = RwLock::new(Config2::load());
+    static ref BOOTSTRAP_CONFIG: RwLock<BootstrapConfig> = RwLock::new(BootstrapConfig::load());
     static ref LOCAL_CONFIG: RwLock<LocalConfig> = RwLock::new(LocalConfig::load());
     static ref STATUS: RwLock<Status> = RwLock::new(Status::load());
     static ref TRUSTED_DEVICES: RwLock<(Vec<TrustedDevice>, bool)> = Default::default();
@@ -155,9 +156,6 @@ const CHARS: &[char] = &[
     '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
     'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
-
-pub const RENDEZVOUS_SERVERS: &[&str] = &["rs-ny.rustdesk.com"];
-pub const RS_PUB_KEY: &str = "OeVuKk5nlHiXp+APNn0Y3pC1Iwpwn44JGqrQCsWqmBw=";
 
 pub const RENDEZVOUS_PORT: i32 = 21116;
 pub const RELAY_PORT: i32 = 21117;
@@ -274,6 +272,42 @@ pub struct Config2 {
     // the other scalar value must before this
     #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
     pub options: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct BootstrapConfig {
+    #[serde(
+        rename = "rendezvous-server",
+        default,
+        deserialize_with = "deserialize_string"
+    )]
+    rendezvous_server: String,
+    #[serde(
+        rename = "rendezvous-servers",
+        default,
+        deserialize_with = "deserialize_vec_string"
+    )]
+    rendezvous_servers: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    key: String,
+    #[serde(
+        rename = "api-server",
+        default,
+        deserialize_with = "deserialize_string"
+    )]
+    api_server: String,
+    #[serde(
+        rename = "update-server",
+        default,
+        deserialize_with = "deserialize_string"
+    )]
+    update_server: String,
+    #[serde(
+        rename = "trusted-peers",
+        default,
+        deserialize_with = "deserialize_hashmap_string_string"
+    )]
+    trusted_peers: HashMap<String, String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
@@ -557,6 +591,32 @@ impl Config2 {
     }
 }
 
+impl BootstrapConfig {
+    fn load() -> BootstrapConfig {
+        Config::load_::<BootstrapConfig>("-bootstrap")
+    }
+
+    pub fn file() -> PathBuf {
+        Config::file_("-bootstrap")
+    }
+
+    fn get_rendezvous_servers(&self) -> Vec<String> {
+        if !self.rendezvous_servers.is_empty() {
+            return self
+                .rendezvous_servers
+                .iter()
+                .filter(|server| !server.is_empty())
+                .cloned()
+                .collect();
+        }
+        if self.rendezvous_server.is_empty() {
+            Vec::new()
+        } else {
+            vec![self.rendezvous_server.clone()]
+        }
+    }
+}
+
 pub fn load_path<T: serde::Serialize + serde::de::DeserializeOwned + Default + std::fmt::Debug>(
     file: PathBuf,
 ) -> T {
@@ -698,6 +758,10 @@ impl Config {
 
     pub fn file() -> PathBuf {
         Self::file_("")
+    }
+
+    pub fn bootstrap_file() -> PathBuf {
+        BootstrapConfig::file()
     }
 
     fn file_(suffix: &str) -> PathBuf {
@@ -850,21 +914,15 @@ impl Config {
     pub fn get_rendezvous_server() -> String {
         let mut rendezvous_server = EXE_RENDEZVOUS_SERVER.read().unwrap().clone();
         if rendezvous_server.is_empty() {
-            rendezvous_server = Self::get_option("custom-rendezvous-server");
-        }
-        if rendezvous_server.is_empty() {
-            rendezvous_server = PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
-        }
-        if rendezvous_server.is_empty() {
-            rendezvous_server = CONFIG2.read().unwrap().rendezvous_server.clone();
-        }
-        if rendezvous_server.is_empty() {
-            rendezvous_server = Self::get_rendezvous_servers()
-                .drain(..)
+            rendezvous_server = Self::get_bootstrap_rendezvous_servers()
+                .into_iter()
                 .next()
                 .unwrap_or_default();
         }
-        if !rendezvous_server.contains(':') {
+        if rendezvous_server.is_empty() {
+            rendezvous_server = Self::get_option("custom-rendezvous-server");
+        }
+        if !rendezvous_server.is_empty() && !rendezvous_server.contains(':') {
             rendezvous_server = format!("{rendezvous_server}:{RENDEZVOUS_PORT}");
         }
         rendezvous_server
@@ -875,26 +933,46 @@ impl Config {
         if !s.is_empty() {
             return vec![s];
         }
+        let ss = Self::get_bootstrap_rendezvous_servers();
+        if !ss.is_empty() {
+            return ss;
+        }
         let s = Self::get_option("custom-rendezvous-server");
         if !s.is_empty() {
             return vec![s];
         }
-        let s = PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
-        if !s.is_empty() {
-            return vec![s];
-        }
-        let serial_obsolute = CONFIG2.read().unwrap().serial > SERIAL;
-        if serial_obsolute {
-            let ss: Vec<String> = Self::get_option("rendezvous-servers")
-                .split(',')
-                .filter(|x| x.contains('.'))
-                .map(|x| x.to_owned())
-                .collect();
-            if !ss.is_empty() {
-                return ss;
-            }
-        }
-        return RENDEZVOUS_SERVERS.iter().map(|x| x.to_string()).collect();
+        Vec::new()
+    }
+
+    pub fn get_bootstrap_rendezvous_servers() -> Vec<String> {
+        BOOTSTRAP_CONFIG.read().unwrap().get_rendezvous_servers()
+    }
+
+    pub fn get_bootstrap_key() -> String {
+        BOOTSTRAP_CONFIG.read().unwrap().key.clone()
+    }
+
+    pub fn get_bootstrap_api_server() -> String {
+        BOOTSTRAP_CONFIG.read().unwrap().api_server.clone()
+    }
+
+    pub fn get_bootstrap_update_server() -> String {
+        BOOTSTRAP_CONFIG.read().unwrap().update_server.clone()
+    }
+
+    pub fn get_bootstrap_trusted_peer_key(peer_id: &str) -> String {
+        BOOTSTRAP_CONFIG
+            .read()
+            .unwrap()
+            .trusted_peers
+            .get(peer_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn set_bootstrap_config_for_test(config: BootstrapConfig) {
+        *BOOTSTRAP_CONFIG.write().unwrap() = config;
     }
 
     pub fn reset_online() {
@@ -1161,6 +1239,9 @@ impl Config {
         let mut res = DEFAULT_SETTINGS.read().unwrap().clone();
         res.extend(CONFIG2.read().unwrap().options.clone());
         res.extend(OVERWRITE_SETTINGS.read().unwrap().clone());
+        for (key, value) in res.iter_mut() {
+            Self::maybe_decrypt_option_value(key, value);
+        }
         res
     }
 
@@ -1171,6 +1252,9 @@ impl Config {
 
     pub fn set_options(mut v: HashMap<String, String>) {
         Self::purify_options(&mut v);
+        for (key, value) in v.iter_mut() {
+            Self::maybe_encrypt_option_value(key, value);
+        }
         let mut config = CONFIG2.write().unwrap();
         if config.options == v {
             return;
@@ -1180,13 +1264,15 @@ impl Config {
     }
 
     pub fn get_option(k: &str) -> String {
-        get_or(
+        let mut value = get_or(
             &OVERWRITE_SETTINGS,
             &CONFIG2.read().unwrap().options,
             &DEFAULT_SETTINGS,
             k,
         )
-        .unwrap_or_default()
+        .unwrap_or_default();
+        Self::maybe_decrypt_option_value(k, &mut value);
+        value
     }
 
     pub fn get_bool_option(k: &str) -> bool {
@@ -1202,15 +1288,43 @@ impl Config {
             return;
         }
         let mut config = CONFIG2.write().unwrap();
-        let v2 = if v.is_empty() { None } else { Some(&v) };
-        if v2 != config.options.get(&k) {
+        let mut stored = v;
+        Self::maybe_encrypt_option_value(&k, &mut stored);
+        let v2 = if stored.is_empty() {
+            None
+        } else {
+            Some(stored.as_str())
+        };
+        if v2 != config.options.get(&k).map(|value| value.as_str()) {
             if v2.is_none() {
                 config.options.remove(&k);
             } else {
-                config.options.insert(k, v);
+                config.options.insert(k, stored);
             }
             config.store();
         }
+    }
+
+    fn is_encrypted_option(k: &str) -> bool {
+        matches!(
+            k,
+            keys::OPTION_DIRECT_ACCESS_PAIRING_PASSPHRASE | keys::OPTION_PEER_PAIRING_PASSPHRASE
+        )
+    }
+
+    fn maybe_decrypt_option_value(k: &str, v: &mut String) {
+        if !Self::is_encrypted_option(k) || v.is_empty() {
+            return;
+        }
+        let (plain, _, _) = decrypt_str_or_original(v, PASSWORD_ENC_VERSION);
+        *v = plain;
+    }
+
+    fn maybe_encrypt_option_value(k: &str, v: &mut String) {
+        if !Self::is_encrypted_option(k) || v.is_empty() {
+            return;
+        }
+        *v = encrypt_str_or_original(v, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
     }
 
     pub fn update_id() {
@@ -2178,6 +2292,8 @@ pub struct DiscoveryPeer {
     #[serde(default, deserialize_with = "deserialize_string")]
     pub id: String,
     #[serde(default, deserialize_with = "deserialize_string")]
+    pub sign_pk: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
     pub username: String,
     #[serde(default, deserialize_with = "deserialize_string")]
     pub hostname: String,
@@ -2809,6 +2925,10 @@ pub mod keys {
     pub const OPTION_ENABLE_LAN_DISCOVERY: &str = "enable-lan-discovery";
     pub const OPTION_DIRECT_SERVER: &str = "direct-server";
     pub const OPTION_DIRECT_ACCESS_PORT: &str = "direct-access-port";
+    pub const OPTION_DIRECT_ACCESS_PAIRING_PASSPHRASE: &str = "direct-access-pairing-passphrase";
+    pub const OPTION_PEER_PAIRING_PASSPHRASE: &str = "peer-pairing-passphrase";
+    pub const OPTION_ALLOW_UNVERIFIED_PEER_TRUST: &str = "allow-unverified-peer-trust";
+    pub const OPTION_LAN_DISCOVERY_MODE: &str = "lan-discovery-mode";
     pub const OPTION_WHITELIST: &str = "whitelist";
     pub const OPTION_ALLOW_AUTO_DISCONNECT: &str = "allow-auto-disconnect";
     pub const OPTION_AUTO_DISCONNECT_TIMEOUT: &str = "auto-disconnect-timeout";
@@ -3035,6 +3155,10 @@ pub mod keys {
         OPTION_ENABLE_LAN_DISCOVERY,
         OPTION_DIRECT_SERVER,
         OPTION_DIRECT_ACCESS_PORT,
+        OPTION_DIRECT_ACCESS_PAIRING_PASSPHRASE,
+        OPTION_PEER_PAIRING_PASSPHRASE,
+        OPTION_ALLOW_UNVERIFIED_PEER_TRUST,
+        OPTION_LAN_DISCOVERY_MODE,
         OPTION_WHITELIST,
         OPTION_ALLOW_AUTO_DISCONNECT,
         OPTION_AUTO_DISCONNECT_TIMEOUT,
@@ -3399,6 +3523,82 @@ mod tests {
                 ..Default::default()
             })
         );
+    }
+
+    #[test]
+    fn test_bootstrap_rendezvous_resolution() {
+        let saved_bootstrap = BOOTSTRAP_CONFIG.read().unwrap().clone();
+        let saved_exe = EXE_RENDEZVOUS_SERVER.read().unwrap().clone();
+        let saved_prod = PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
+        let saved_config2 = CONFIG2.read().unwrap().clone();
+
+        Config::set_bootstrap_config_for_test(BootstrapConfig::default());
+        *EXE_RENDEZVOUS_SERVER.write().unwrap() = "".to_owned();
+        *PROD_RENDEZVOUS_SERVER.write().unwrap() = "".to_owned();
+        {
+            let mut config2 = CONFIG2.write().unwrap();
+            config2.rendezvous_server.clear();
+            config2.serial = 0;
+            config2.options.clear();
+        }
+
+        assert_eq!(Config::get_rendezvous_server(), "");
+        assert!(Config::get_rendezvous_servers().is_empty());
+
+        let bootstrap = BootstrapConfig {
+            rendezvous_servers: vec!["lan-only.example".to_owned(), "vpn-only.example".to_owned()],
+            key: "bootstrap-key".to_owned(),
+            api_server: "http://lan-only.example:21114".to_owned(),
+            update_server: "http://updates.example/version/latest".to_owned(),
+            trusted_peers: HashMap::from([(
+                "peer-1".to_owned(),
+                "peer-1-base64-signing-key".to_owned(),
+            )]),
+            ..Default::default()
+        };
+        Config::set_bootstrap_config_for_test(bootstrap);
+        {
+            let mut config2 = CONFIG2.write().unwrap();
+            config2.rendezvous_server = "cached.example".to_owned();
+            config2.options.insert(
+                "custom-rendezvous-server".to_owned(),
+                "mutable.example".to_owned(),
+            );
+            config2.options.insert(
+                "rendezvous-servers".to_owned(),
+                "server-pushed.example,ignored.example".to_owned(),
+            );
+            config2.serial = SERIAL + 1;
+        }
+
+        assert_eq!(
+            Config::get_rendezvous_server(),
+            format!("lan-only.example:{RENDEZVOUS_PORT}")
+        );
+        assert_eq!(
+            Config::get_rendezvous_servers(),
+            vec!["lan-only.example".to_owned(), "vpn-only.example".to_owned()]
+        );
+        assert_ne!(Config::get_rendezvous_server(), "cached.example:21116");
+        assert_eq!(Config::get_bootstrap_key(), "bootstrap-key");
+        assert_eq!(
+            Config::get_bootstrap_api_server(),
+            "http://lan-only.example:21114"
+        );
+        assert_eq!(
+            Config::get_bootstrap_update_server(),
+            "http://updates.example/version/latest"
+        );
+        assert_eq!(
+            Config::get_bootstrap_trusted_peer_key("peer-1"),
+            "peer-1-base64-signing-key"
+        );
+        assert_eq!(Config::get_bootstrap_trusted_peer_key("missing"), "");
+
+        Config::set_bootstrap_config_for_test(saved_bootstrap);
+        *EXE_RENDEZVOUS_SERVER.write().unwrap() = saved_exe;
+        *PROD_RENDEZVOUS_SERVER.write().unwrap() = saved_prod;
+        *CONFIG2.write().unwrap() = saved_config2;
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,8 +493,6 @@ pub const VER_TYPE_RUSTDESK_CLIENT: &str = "rustdesk-client";
 pub const VER_TYPE_RUSTDESK_SERVER: &str = "rustdesk-server";
 
 pub fn version_check_request(typ: String) -> (VersionCheckRequest, String) {
-    const URL: &str = "https://api.rustdesk.com/version/latest";
-
     use sysinfo::System;
     let system = System::new();
     let os = system.distribution_id();
@@ -510,7 +508,7 @@ pub fn version_check_request(typ: String) -> (VersionCheckRequest, String) {
             device_id,
             typ,
         },
-        URL.to_string(),
+        config::Config::get_bootstrap_update_server(),
     )
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,6 @@
-use crate::{config, tcp, websocket, ResultType};
 #[cfg(feature = "webrtc")]
 use crate::webrtc;
+use crate::{config, tcp, websocket, ResultType};
 use sodiumoxide::crypto::secretbox::Key;
 use std::net::SocketAddr;
 use tokio::net::TcpStream;
@@ -14,6 +14,16 @@ pub enum Stream {
 }
 
 impl Stream {
+    #[inline]
+    pub fn has_secure_transport(&self) -> bool {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(_) => true,
+            Stream::WebSocket(s) => s.has_tls_transport(),
+            Stream::Tcp(_) => false,
+        }
+    }
+
     #[inline]
     pub fn set_send_timeout(&mut self, ms: u64) {
         match self {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -36,6 +36,13 @@ pub struct WsFramedStream {
 }
 
 impl WsFramedStream {
+    pub fn has_tls_transport(&self) -> bool {
+        matches!(
+            self.stream.get_ref(),
+            MaybeTlsStream::NativeTls(_) | MaybeTlsStream::Rustls(_)
+        )
+    }
+
     #[inline]
     fn get_connector(
         tls_type: &TlsType,
@@ -380,7 +387,12 @@ pub fn check_ws(endpoint: &str) -> String {
         (format!("{}{}", endpoint_host, domain_path), true)
     };
     let protocol = if is_domain {
-        let api_server = Config::get_option("api-server");
+        let api_server = Config::get_bootstrap_api_server();
+        let api_server = if api_server.is_empty() {
+            Config::get_option("api-server")
+        } else {
+            api_server
+        };
         if api_server.starts_with("https") {
             "wss"
         } else {


### PR DESCRIPTION
This is a part of RustDesk client security hardening PR:

## Summary

This PR adds the shared transport and bootstrap changes needed for a stricter client trust model.

Main changes:

- add an explicit bootstrap config layer for fixed infrastructure and trust roots
- remove legacy rendezvous fallback paths when no explicit bootstrap or user config is present
- add bootstrap `trusted-peers` support for preseeded peer identity trust
- encrypt pairing passphrase options at rest
- cap framed packet decoding to 64 MiB
- expose secure transport detection used by the client to avoid fail-open behavior

## Why

The previous client behavior mixed mutable runtime config with implicit fallback behavior. In practice, that meant:

- an unconfigured client could still slide onto public infrastructure paths
- remote config and cached state had too much influence over endpoint selection
- pairing passphrases were stored too loosely
- framed transport parsing accepted attacker-chosen allocation sizes

This PR moves the shared layer toward explicit trust and fail-closed behavior.

## Design Decisions

### 1. Separate bootstrap trust roots from mutable runtime options

`BootstrapConfig` is loaded from a dedicated `-bootstrap` file and is intended for values that should not silently drift at runtime:

- rendezvous server list
- server signing key
- API server
- update server
- trusted peer signing keys

That keeps deployer-provided trust roots separate from ordinary mutable option state.

### 2. Remove implicit rendezvous fallback

When no explicit bootstrap or user-provided rendezvous server exists, shared config resolution now stays empty instead of reintroducing legacy fallback paths.

This is important for:

- local-only deployments
- private/self-hosted distributions
- fail-closed behavior when config is incomplete

### 3. Preseed peer trust with bootstrap `trusted-peers`

Bootstrap `trusted-peers` allows a distributor to ship known peer signing keys up front. This supports first-contact trust without depending only on interactive trust-on-first-use.

### 4. Bound framed message size

The frame decoder now rejects oversized packets before reserving memory. This is a direct hardening step against remote memory exhaustion.

### 5. Encrypt pairing passphrases at rest

Pairing passphrase options are now treated like other protected secrets and stored encrypted rather than plaintext.

## Operational Impact

This PR changes shared config behavior in an intentional way:

- explicit bootstrap config is now the preferred way to ship fixed infrastructure
- absence of explicit endpoint config no longer implies a default rendezvous path
- client-side peer trust can now be preseeded from bootstrap config

## Compatibility

This PR is intended to be consumed together with the matching `rustdesk-client` security PR. The client PR uses:

- bootstrap trusted peers
- stricter endpoint resolution
- encrypted pairing passphrase storage
- secure transport/fail-closed helpers

## Example Bootstrap Config

The matching client PR adds an example bootstrap file showing the intended packaging model:

- `rendezvous-servers`
- `key`
- `api-server`
- `update-server`
- `[trusted-peers]`

## Testing

Verified in the client workspace against the matching branch with:

- targeted bootstrap resolution checks
- framed packet limit tests
- client compile/build validation against the updated shared API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootstrap configuration system for centralized server, API and update settings.
  * Configuration options transparently encrypt/decrypt stored values.
  * New checks to detect whether a connection/transport is secure.
  * Protocols now accept a licence key in peer/registration/online requests.

* **Bug Fixes**
  * Enforced a 64 MB default packet size limit to reject oversized packets.

* **Behavior Changes**
  * Version/update and WebSocket scheme now prefer bootstrap-configured servers.
  * New peer/trust and pairing option keys added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->