### PR TITLE
add cross-platform user-scoped secret storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ base64 = "0.22"
 url = "2.5"
 sha2 = "0.10"
 whoami = "1.5"
+once_cell = "1"
 
 tokio-rustls = { version = "0.26", features = [
     "logging",
@@ -88,6 +89,10 @@ winapi = { version = "0.3", features = [
     "memoryapi",
     "sysinfoapi",
 ] }
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security_Cryptography",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 osascript = "0.3"
@@ -98,3 +103,10 @@ sctk = { package = "smithay-client-toolkit", version = "0.20.0", default-feature
 ] }
 users = { version = "0.11" }
 x11 = "2.21"
+dbus-secret-service = { version = "=4.0.3", features = ["crypto-rust"] }
+ashpd = { version = "0.9", default-features = false, features = ["tokio"] }
+# Pin indexmap version for current toolchain compatibility, transitive dependency from ashpd
+indexmap = "=2.2.6"
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+security-framework = { version = "3", features = ["OSX_10_15"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ base64 = "0.22"
 url = "2.5"
 sha2 = "0.10"
 whoami = "1.5"
-once_cell = "1"
+once_cell = "1.18"
 
 tokio-rustls = { version = "0.26", features = [
     "logging",

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,7 @@ use crate::{
     log,
     password_security::{
         decrypt_str_or_original, decrypt_vec_or_original, encrypt_str_or_original,
-        encrypt_vec_or_original, symmetric_crypt,
+        encrypt_vec_or_original, VERSION_00_UUID, VERSION_02_USER,
     },
 };
 
@@ -39,7 +39,11 @@ pub const READ_TIMEOUT: u64 = 18_000;
 pub const REG_INTERVAL: i64 = 15_000;
 pub const COMPRESS_LEVEL: i32 = 3;
 const SERIAL: i32 = 3;
-const PASSWORD_ENC_VERSION: &str = "00";
+const GLOBAL_ENC_VERSION: &str = VERSION_00_UUID;
+#[cfg(target_os = "android")]
+const USER_ENC_VERSION: &str = VERSION_00_UUID;
+#[cfg(not(target_os = "android"))]
+const USER_ENC_VERSION: &str = VERSION_02_USER;
 pub const ENCRYPT_MAX_LEN: usize = 128; // used for password, pin, etc, not for all
 
 const PERMANENT_PASSWORD_HASH_PREFIX: &str = "01";
@@ -511,13 +515,13 @@ impl Config2 {
         let mut store = false;
         if let Some(mut socks) = config.socks {
             let (password, _, store2) =
-                decrypt_str_or_original(&socks.password, PASSWORD_ENC_VERSION);
+                decrypt_str_or_original(&socks.password, GLOBAL_ENC_VERSION);
             socks.password = password;
             config.socks = Some(socks);
             store |= store2;
         }
         let (unlock_pin, _, store2) =
-            decrypt_str_or_original(&config.unlock_pin, PASSWORD_ENC_VERSION);
+            decrypt_str_or_original(&config.unlock_pin, GLOBAL_ENC_VERSION);
         config.unlock_pin = unlock_pin;
         store |= store2;
         if store {
@@ -534,11 +538,11 @@ impl Config2 {
         let mut config = self.clone();
         if let Some(mut socks) = config.socks {
             socks.password =
-                encrypt_str_or_original(&socks.password, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+                encrypt_str_or_original(&socks.password, GLOBAL_ENC_VERSION, ENCRYPT_MAX_LEN);
             config.socks = Some(socks);
         }
         config.unlock_pin =
-            encrypt_str_or_original(&config.unlock_pin, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+            encrypt_str_or_original(&config.unlock_pin, GLOBAL_ENC_VERSION, ENCRYPT_MAX_LEN);
         Config::store_(&config, "2");
     }
 
@@ -616,7 +620,7 @@ impl Config {
         let mut store = false;
         store |= Self::migrate_permanent_password_to_hashed_storage(&mut config);
         let mut id_valid = false;
-        let (id, encrypted, store2) = decrypt_str_or_original(&config.enc_id, PASSWORD_ENC_VERSION);
+        let (id, encrypted, store2) = decrypt_str_or_original(&config.enc_id, GLOBAL_ENC_VERSION);
         if encrypted {
             config.id = id;
             id_valid = true;
@@ -630,7 +634,7 @@ impl Config {
         // &&
         !config.id.is_empty()
             && config.enc_id.is_empty()
-            && !decrypt_str_or_original(&config.id, PASSWORD_ENC_VERSION).1
+            && !decrypt_str_or_original(&config.id, GLOBAL_ENC_VERSION).1
         {
             id_valid = true;
             store = true;
@@ -658,9 +662,9 @@ impl Config {
             return false;
         }
 
-        if config.password.starts_with(PASSWORD_ENC_VERSION) {
+        if config.password.starts_with(VERSION_00_UUID) {
             let (plain, decrypted, looks_like_plaintext) =
-                decrypt_str_or_original(&config.password, PASSWORD_ENC_VERSION);
+                decrypt_str_or_original(&config.password, VERSION_00_UUID);
             // `decrypt_str_or_original` returns (value, decrypted_ok, should_store).
             // If the value looks like an encrypted payload ("00" + base64 with MAC) but cannot be
             // decrypted on this machine, it is most likely copied from another device or corrupted.
@@ -691,7 +695,7 @@ impl Config {
     fn store(&self) {
         let mut config = self.clone();
         Self::migrate_permanent_password_to_hashed_storage(&mut config);
-        config.enc_id = encrypt_str_or_original(&config.id, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+        config.enc_id = encrypt_str_or_original(&config.id, GLOBAL_ENC_VERSION, ENCRYPT_MAX_LEN);
         config.id = "".to_owned();
         Config::store_(&config, "");
     }
@@ -1090,7 +1094,7 @@ impl Config {
 
         // IMPORTANT: this path is called while holding KEY_PAIR lock.
         // Config::load_ must remain a raw conf load/deserialize path and must never
-        // call decrypt_* / symmetric_crypt (directly or indirectly), otherwise this
+        // call decrypt_* / symmetric_crypt_* (directly or indirectly), otherwise this
         // can re-enter key loading and deadlock.
         let config = Config::load_::<Config>("");
         if !config.key_pair.0.is_empty() {
@@ -1499,7 +1503,7 @@ impl Config {
             return devices;
         }
         let devices = CONFIG2.read().unwrap().trusted_devices.clone();
-        let (devices, succ, store) = decrypt_str_or_original(&devices, PASSWORD_ENC_VERSION);
+        let (devices, succ, store) = decrypt_str_or_original(&devices, GLOBAL_ENC_VERSION);
         if succ {
             let mut devices: Vec<TrustedDevice> =
                 serde_json::from_str(&devices).unwrap_or_default();
@@ -1523,7 +1527,7 @@ impl Config {
             log::error!("Trusted devices too large: {}", devices.bytes().len());
             return;
         }
-        let devices = encrypt_str_or_original(&devices, PASSWORD_ENC_VERSION, max_len);
+        let devices = encrypt_str_or_original(&devices, GLOBAL_ENC_VERSION, max_len);
         let mut config = CONFIG2.write().unwrap();
         config.trusted_devices = devices;
         config.store();
@@ -1606,13 +1610,12 @@ impl PeerConfig {
                 let mut config: PeerConfig = config;
                 let mut store = false;
                 let (password, _, store2) =
-                    decrypt_vec_or_original(&config.password, PASSWORD_ENC_VERSION);
+                    decrypt_vec_or_original(&config.password, USER_ENC_VERSION);
                 config.password = password;
                 store = store || store2;
                 for opt in ["rdp_password", "os-username", "os-password"] {
                     if let Some(v) = config.options.get_mut(opt) {
-                        let (encrypted, _, store2) =
-                            decrypt_str_or_original(v, PASSWORD_ENC_VERSION);
+                        let (encrypted, _, store2) = decrypt_str_or_original(v, USER_ENC_VERSION);
                         *v = encrypted;
                         store = store || store2;
                     }
@@ -1642,10 +1645,10 @@ impl PeerConfig {
     fn store_(&self, id: &str) {
         let mut config = self.clone();
         config.password =
-            encrypt_vec_or_original(&config.password, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+            encrypt_vec_or_original(&config.password, USER_ENC_VERSION, ENCRYPT_MAX_LEN);
         for opt in ["rdp_password", "os-username", "os-password"] {
             if let Some(v) = config.options.get_mut(opt) {
-                *v = encrypt_str_or_original(v, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN)
+                *v = encrypt_str_or_original(v, USER_ENC_VERSION, ENCRYPT_MAX_LEN);
             }
         }
         if let Err(err) = store_path(Self::path(id), config) {
@@ -2038,13 +2041,69 @@ pub struct LocalConfig {
     ui_flutter: HashMap<String, String>,
 }
 
-impl LocalConfig {
-    fn load() -> LocalConfig {
-        Config::load_::<LocalConfig>("_local")
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub(crate) struct SecretStatus {
+    #[serde(default, deserialize_with = "deserialize_bool")]
+    skip_load: bool,
+}
+
+impl SecretStatus {
+    pub(crate) fn load() -> Self {
+        Config::load_::<Self>("_secret_status")
     }
 
     fn store(&self) {
-        Config::store_(self, "_local");
+        Config::store_(self, "_secret_status");
+    }
+
+    pub(crate) fn should_skip_load(&self) -> bool {
+        self.skip_load
+    }
+
+    pub(crate) fn mark_skip_load() {
+        let mut status = Self::load();
+        if status.skip_load {
+            return;
+        }
+        status.skip_load = true;
+        status.store();
+    }
+}
+
+impl LocalConfig {
+    const ACCESS_TOKEN_KEY: &'static str = "access_token";
+
+    fn load() -> LocalConfig {
+        let mut config = Config::load_::<LocalConfig>("_local");
+        let mut store = false;
+        if let Some(access_token) = config.options.get_mut(Self::ACCESS_TOKEN_KEY) {
+            let (token, _, store2) = decrypt_str_or_original(access_token, USER_ENC_VERSION);
+            *access_token = token;
+            store |= store2;
+        }
+        if store {
+            config.store();
+        }
+        config
+    }
+
+    fn store(&self) {
+        const ACCESS_TOKEN_MAX_LEN: usize = 1024;
+
+        let mut config = self.clone();
+        if let Some(access_token) = config.options.get_mut(Self::ACCESS_TOKEN_KEY) {
+            if access_token.chars().count() <= ACCESS_TOKEN_MAX_LEN {
+                *access_token =
+                    encrypt_str_or_original(access_token, USER_ENC_VERSION, ACCESS_TOKEN_MAX_LEN);
+            } else {
+                log::error!(
+                    "access_token too large to encrypt, keeping original value: {} > {}",
+                    access_token.chars().count(),
+                    ACCESS_TOKEN_MAX_LEN
+                );
+            }
+        }
+        Config::store_(&config, "_local");
     }
 
     pub fn get_kb_layout_type() -> String {
@@ -2447,8 +2506,9 @@ impl Ab {
                 log::error!("ab data too large, {} > {}", data.len(), max_len);
                 return;
             }
-            if let Ok(data) = symmetric_crypt(&data, true) {
-                file.write_all(&data).ok();
+            let encrypted = encrypt_vec_or_original(&data, USER_ENC_VERSION, max_len);
+            if encrypted != data {
+                file.write_all(&encrypted).ok();
             }
         };
     }
@@ -2457,7 +2517,8 @@ impl Ab {
         if let Ok(mut file) = std::fs::File::open(Self::path()) {
             let mut data = vec![];
             if file.read_to_end(&mut data).is_ok() {
-                if let Ok(data) = symmetric_crypt(&data, false) {
+                let (data, success, _) = decrypt_vec_or_original(&data, USER_ENC_VERSION);
+                if success {
                     let data = decompress(&data);
                     if let Ok(ab) = serde_json::from_str::<Ab>(&String::from_utf8_lossy(&data)) {
                         return ab;
@@ -2576,8 +2637,9 @@ impl Group {
                 // maxlen of function decompress
                 return;
             }
-            if let Ok(data) = symmetric_crypt(&data, true) {
-                file.write_all(&data).ok();
+            let encrypted = encrypt_vec_or_original(&data, USER_ENC_VERSION, max_len);
+            if encrypted != data {
+                file.write_all(&encrypted).ok();
             }
         };
     }
@@ -2586,7 +2648,8 @@ impl Group {
         if let Ok(mut file) = std::fs::File::open(Self::path()) {
             let mut data = vec![];
             if file.read_to_end(&mut data).is_ok() {
-                if let Ok(data) = symmetric_crypt(&data, false) {
+                let (data, success, _) = decrypt_vec_or_original(&data, USER_ENC_VERSION);
+                if success {
                     let data = decompress(&data);
                     if let Ok(group) = serde_json::from_str::<Self>(&String::from_utf8_lossy(&data))
                     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use futures_util;
 pub mod config;
 pub mod fs;
 pub mod mem;
+pub mod secret_store;
 pub use lazy_static;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use mac_address;
@@ -58,9 +59,9 @@ pub use uuid;
 pub mod fingerprint;
 pub use flexi_logger;
 pub mod stream;
-pub mod websocket;
 #[cfg(feature = "webrtc")]
 pub mod webrtc;
+pub mod websocket;
 #[cfg(any(target_os = "android", target_os = "ios"))]
 pub use rustls_platform_verifier;
 pub use stream::Stream;
@@ -68,9 +69,9 @@ pub use whoami;
 pub mod tls;
 pub mod verifier;
 pub use async_recursion;
+pub use libloading;
 #[cfg(target_os = "linux")]
 pub use users;
-pub use libloading;
 #[cfg(target_os = "linux")]
 pub use x11;
 
@@ -432,7 +433,10 @@ pub fn init_log(_is_async: bool, _name: &str) -> Option<flexi_logger::LoggerHand
         #[cfg(debug_assertions)]
         {
             use env_logger::*;
-            init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info,reqwest=warn,rustls=warn,webrtc-sctp=warn,webrtc=warn"));
+            init_from_env(Env::default().filter_or(
+                DEFAULT_FILTER_ENV,
+                "info,reqwest=warn,rustls=warn,webrtc-sctp=warn,webrtc=warn",
+            ));
         }
         #[cfg(not(debug_assertions))]
         {
@@ -447,7 +451,9 @@ pub fn init_log(_is_async: bool, _name: &str) -> Option<flexi_logger::LoggerHand
                 path.push(_name);
             }
             use flexi_logger::*;
-            if let Ok(x) = Logger::try_with_env_or_str("debug,reqwest=warn,rustls=warn,webrtc-sctp=warn,webrtc=warn") {
+            if let Ok(x) = Logger::try_with_env_or_str(
+                "debug,reqwest=warn,rustls=warn,webrtc-sctp=warn,webrtc=warn",
+            ) {
                 logger_holder = x
                     .log_to_file(FileSpec::default().directory(path))
                     .write_mode(if _is_async {

--- a/src/password_security.rs
+++ b/src/password_security.rs
@@ -92,37 +92,168 @@ pub fn hide_cm() -> bool {
 }
 
 const VERSION_LEN: usize = 2;
+pub const VERSION_00_UUID: &str = "00";
+pub const VERSION_02_USER: &str = "02";
 
-// Check if data is already encrypted by verifying:
-// 1) version prefix "00"
-// 2) valid base64 payload
-// 3) decoded payload length >= secretbox::MACBYTES
-//
-// We intentionally avoid trying to decrypt here because key mismatch would cause
-// false negatives.
-// Reference: secretbox::seal returns ciphertext length = plaintext length + MACBYTES
-// https://github.com/sodiumoxide/sodiumoxide/blob/3057acb1a030ad86ed8892a223d64036ab5e8523/src/crypto/secretbox/xsalsa20poly1305.rs#L67
-fn is_encrypted(v: &[u8]) -> bool {
-    if v.len() <= VERSION_LEN || !v.starts_with(b"00") {
+#[derive(Debug)]
+pub enum CryptError {
+    EncryptionFailed,
+    DecryptionFailed,
+    InvalidData,
+    Base64Error,
+}
+
+trait Cipher {
+    fn version(&self) -> &'static str;
+    fn encrypt(&self, data: &[u8], is_string: bool) -> Result<Vec<u8>, CryptError>;
+    fn decrypt(&self, data: &[u8], is_string: bool) -> Result<Vec<u8>, CryptError>;
+}
+
+struct UuidCipher;
+struct UserCipher;
+
+static UUID_CIPHER: UuidCipher = UuidCipher;
+static USER_CIPHER: UserCipher = UserCipher;
+
+impl Cipher for UuidCipher {
+    fn version(&self) -> &'static str {
+        VERSION_00_UUID
+    }
+
+    fn encrypt(&self, data: &[u8], _is_string: bool) -> Result<Vec<u8>, CryptError> {
+        symmetric_crypt_00_uuid(data, true)
+            .map(|payload| base64::encode(payload, base64::Variant::Original).into_bytes())
+            .map_err(|_| CryptError::EncryptionFailed)
+    }
+
+    fn decrypt(&self, data: &[u8], _is_string: bool) -> Result<Vec<u8>, CryptError> {
+        let payload =
+            base64::decode(data, base64::Variant::Original).map_err(|_| CryptError::Base64Error)?;
+        symmetric_crypt_00_uuid(&payload, false).map_err(|_| CryptError::DecryptionFailed)
+    }
+}
+
+impl Cipher for UserCipher {
+    fn version(&self) -> &'static str {
+        VERSION_02_USER
+    }
+
+    fn encrypt(&self, data: &[u8], is_string: bool) -> Result<Vec<u8>, CryptError> {
+        let payload = symmetric_crypt_02_user(data, true)?;
+        if is_string {
+            Ok(base64::encode(payload, base64::Variant::Original).into_bytes())
+        } else {
+            Ok(payload)
+        }
+    }
+
+    fn decrypt(&self, data: &[u8], is_string: bool) -> Result<Vec<u8>, CryptError> {
+        if is_string {
+            let payload = base64::decode(data, base64::Variant::Original)
+                .map_err(|_| CryptError::Base64Error)?;
+            symmetric_crypt_02_user(&payload, false)
+        } else {
+            symmetric_crypt_02_user(data, false)
+        }
+    }
+}
+
+fn cipher_by_version(version: &str) -> Option<&'static dyn Cipher> {
+    match version {
+        VERSION_00_UUID => Some(&UUID_CIPHER),
+        VERSION_02_USER => Some(&USER_CIPHER),
+        _ => None,
+    }
+}
+
+fn cipher_by_prefixed_data(v: &[u8]) -> Option<&'static dyn Cipher> {
+    if v.len() <= VERSION_LEN {
+        return None;
+    }
+    if v.starts_with(VERSION_00_UUID.as_bytes()) {
+        Some(&UUID_CIPHER)
+    } else if v.starts_with(VERSION_02_USER.as_bytes()) {
+        Some(&USER_CIPHER)
+    } else {
+        None
+    }
+}
+
+fn should_store_after_decrypt(
+    version: &str,
+    decrypted: &[u8],
+    current_version: &str,
+    is_string: bool,
+) -> bool {
+    if version == current_version {
         return false;
     }
-    match base64::decode(&v[VERSION_LEN..], base64::Variant::Original) {
-        Ok(decoded) => decoded.len() >= sodiumoxide::crypto::secretbox::MACBYTES,
-        Err(_) => false,
+    // Version 02 is user/platform scoped, so only request a store when the
+    // current runtime can actually re-encrypt into that format. For older or
+    // unknown target versions we keep returning true so callers can rewrite the
+    // value on the next successful save.
+    if current_version == VERSION_02_USER {
+        if let Some(cipher) = cipher_by_version(current_version) {
+            return cipher.encrypt(decrypted, is_string).is_ok();
+        }
+    }
+    true
+}
+
+// Check if data is already encrypted by verifying version prefix and payload shape.
+// We avoid trying to decrypt here because key mismatch would cause false negatives.
+fn is_encrypted(v: &[u8], is_string: bool) -> bool {
+    let Some(cipher) = cipher_by_prefixed_data(v) else {
+        return false;
+    };
+
+    let is_known_encrypted_payload = |version: &str, payload: &[u8]| match version {
+        VERSION_00_UUID => payload.len() >= sodiumoxide::crypto::secretbox::MACBYTES,
+        VERSION_02_USER => crate::secret_store::is_encrypted_user_data(payload),
+        _ => false,
+    };
+    let is_base64_encrypted_payload =
+        |version: &str, payload: &[u8]| match base64::decode(payload, base64::Variant::Original) {
+            Ok(decoded) => is_known_encrypted_payload(version, &decoded),
+            Err(_) => false,
+        };
+
+    let payload = &v[VERSION_LEN..];
+    match cipher.version() {
+        VERSION_00_UUID => is_base64_encrypted_payload(cipher.version(), payload),
+        VERSION_02_USER => {
+            if is_string {
+                is_base64_encrypted_payload(cipher.version(), payload)
+            } else {
+                is_known_encrypted_payload(cipher.version(), payload)
+            }
+        }
+        _ => false,
     }
 }
 
 pub fn encrypt_str_or_original(s: &str, version: &str, max_len: usize) -> String {
-    if is_encrypted(s.as_bytes()) {
+    if is_encrypted(s.as_bytes(), true) {
         log::error!("Duplicate encryption!");
+        return s.to_owned();
+    }
+    if s.is_empty() {
         return s.to_owned();
     }
     if s.chars().count() > max_len {
         return String::default();
     }
-    if version == "00" {
-        if let Ok(s) = encrypt(s.as_bytes()) {
-            return version.to_owned() + &s;
+    let mut versions = vec![version];
+    if version == VERSION_02_USER {
+        versions.push(VERSION_00_UUID);
+    }
+    for encrypt_version in versions {
+        if let Some(cipher) = cipher_by_version(encrypt_version) {
+            if let Ok(encrypted) = cipher.encrypt(s.as_bytes(), true) {
+                if let Ok(encrypted) = String::from_utf8(encrypted) {
+                    return encrypt_version.to_owned() + &encrypted;
+                }
+            }
         }
     }
     s.to_owned()
@@ -131,18 +262,12 @@ pub fn encrypt_str_or_original(s: &str, version: &str, max_len: usize) -> String
 // String: password
 // bool: whether decryption is successful
 // bool: whether should store to re-encrypt when load
-// note: s.len() return length in bytes, s.chars().count() return char count
-//       &[..2] return the left 2 bytes, s.chars().take(2) return the left 2 chars
 pub fn decrypt_str_or_original(s: &str, current_version: &str) -> (String, bool, bool) {
-    if s.len() > VERSION_LEN {
-        if s.starts_with("00") {
-            if let Ok(v) = decrypt(s[VERSION_LEN..].as_bytes()) {
-                return (
-                    String::from_utf8_lossy(&v).to_string(),
-                    true,
-                    "00" != current_version,
-                );
-            }
+    if let Some(cipher) = cipher_by_prefixed_data(s.as_bytes()) {
+        let payload = s[VERSION_LEN..].as_bytes();
+        if let Ok(v) = cipher.decrypt(payload, true) {
+            let store = should_store_after_decrypt(cipher.version(), &v, current_version, true);
+            return (String::from_utf8_lossy(&v).to_string(), true, store);
         }
     }
 
@@ -151,23 +276,32 @@ pub fn decrypt_str_or_original(s: &str, current_version: &str) -> (String, bool,
     (
         s.to_owned(),
         false,
-        !s.is_empty() && !is_encrypted(s.as_bytes()),
+        !s.is_empty() && !is_encrypted(s.as_bytes(), true),
     )
 }
 
 pub fn encrypt_vec_or_original(v: &[u8], version: &str, max_len: usize) -> Vec<u8> {
-    if is_encrypted(v) {
+    if is_encrypted(v, false) {
         log::error!("Duplicate encryption!");
+        return v.to_owned();
+    }
+    if v.is_empty() {
         return v.to_owned();
     }
     if v.len() > max_len {
         return vec![];
     }
-    if version == "00" {
-        if let Ok(s) = encrypt(v) {
-            let mut version = version.to_owned().into_bytes();
-            version.append(&mut s.into_bytes());
-            return version;
+    let mut versions = vec![version];
+    if version == VERSION_02_USER {
+        versions.push(VERSION_00_UUID);
+    }
+    for encrypt_version in versions {
+        if let Some(cipher) = cipher_by_version(encrypt_version) {
+            if let Ok(mut encrypted) = cipher.encrypt(v, false) {
+                let mut prefixed = encrypt_version.as_bytes().to_vec();
+                prefixed.append(&mut encrypted);
+                return prefixed;
+            }
         }
     }
     v.to_owned()
@@ -177,44 +311,31 @@ pub fn encrypt_vec_or_original(v: &[u8], version: &str, max_len: usize) -> Vec<u
 // bool: whether decryption is successful
 // bool: whether should store to re-encrypt when load
 pub fn decrypt_vec_or_original(v: &[u8], current_version: &str) -> (Vec<u8>, bool, bool) {
-    if v.len() > VERSION_LEN {
-        let version = String::from_utf8_lossy(&v[..VERSION_LEN]);
-        if version == "00" {
-            if let Ok(v) = decrypt(&v[VERSION_LEN..]) {
-                return (v, true, version != current_version);
-            }
+    if let Some(cipher) = cipher_by_prefixed_data(v) {
+        let payload = &v[VERSION_LEN..];
+        if let Ok(v) = cipher.decrypt(payload, false) {
+            let store = should_store_after_decrypt(cipher.version(), &v, current_version, false);
+            return (v, true, store);
         }
     }
 
-    // For values that already look encrypted (version prefix + base64), avoid
-    // repeated store on each load when decryption fails.
-    (v.to_owned(), false, !v.is_empty() && !is_encrypted(v))
+    // For values that already look encrypted (version prefix + raw payload
+    // shape), avoid repeated store on each load when decryption fails.
+    (
+        v.to_owned(),
+        false,
+        !v.is_empty() && !is_encrypted(v, false),
+    )
 }
 
-fn encrypt(v: &[u8]) -> Result<String, ()> {
-    if !v.is_empty() {
-        symmetric_crypt(v, true).map(|v| base64::encode(v, base64::Variant::Original))
-    } else {
-        Err(())
-    }
-}
-
-fn decrypt(v: &[u8]) -> Result<Vec<u8>, ()> {
-    if !v.is_empty() {
-        base64::decode(v, base64::Variant::Original).and_then(|v| symmetric_crypt(&v, false))
-    } else {
-        Err(())
-    }
-}
-
-pub fn symmetric_crypt(data: &[u8], encrypt: bool) -> Result<Vec<u8>, ()> {
+fn symmetric_crypt_00_uuid(data: &[u8], encrypt: bool) -> Result<Vec<u8>, CryptError> {
     use sodiumoxide::crypto::secretbox;
     use std::convert::TryInto;
 
     let uuid = crate::get_uuid();
     let mut keybuf = uuid.clone();
     keybuf.resize(secretbox::KEYBYTES, 0);
-    let key = secretbox::Key(keybuf.try_into().map_err(|_| ())?);
+    let key = secretbox::Key(keybuf.try_into().map_err(|_| CryptError::InvalidData)?);
     let nonce = secretbox::Nonce([0; secretbox::NONCEBYTES]);
 
     if encrypt {
@@ -229,146 +350,215 @@ pub fn symmetric_crypt(data: &[u8], encrypt: bool) -> Result<Vec<u8>, ()> {
                 if pk != uuid {
                     let mut keybuf = pk;
                     keybuf.resize(secretbox::KEYBYTES, 0);
-                    let pk_key = secretbox::Key(keybuf.try_into().map_err(|_| ())?);
-                    return secretbox::open(data, &nonce, &pk_key);
+                    let pk_key =
+                        secretbox::Key(keybuf.try_into().map_err(|_| CryptError::InvalidData)?);
+                    return secretbox::open(data, &nonce, &pk_key)
+                        .map_err(|_| CryptError::DecryptionFailed);
                 }
             }
         }
-        res
+        res.map_err(|_| CryptError::DecryptionFailed)
+    }
+}
+
+// Version 02 uses platform/user-scoped encryption.
+fn symmetric_crypt_02_user(data: &[u8], encrypt: bool) -> Result<Vec<u8>, CryptError> {
+    if encrypt {
+        #[cfg(target_os = "windows")]
+        let payload =
+            crate::platform::dpapi_encrypt_bytes(data).map_err(|_| CryptError::EncryptionFailed)?;
+        #[cfg(not(target_os = "windows"))]
+        let payload = crate::secret_store::secretbox_encrypt_user_data_raw(data)?;
+
+        Ok(crate::secret_store::user_data_add_magic_header(payload))
+    } else {
+        let (payload, has_header) = crate::secret_store::user_data_strip_magic_header(data);
+        if !has_header {
+            return Err(CryptError::InvalidData);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            crate::platform::dpapi_decrypt_bytes(payload).map_err(|_| CryptError::DecryptionFailed)
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            crate::secret_store::secretbox_decrypt_user_data_raw(payload)
+        }
     }
 }
 
 mod test {
+    use super::*;
+
+    const MAX_LEN: usize = 128;
+
+    fn assert_str_round_trip(data: &str, stored_version: &str, current_version: &str, store: bool) {
+        let encrypted = encrypt_str_or_original(data, stored_version, MAX_LEN);
+        let (decrypted, succ, should_store) = decrypt_str_or_original(&encrypted, current_version);
+        assert_eq!(decrypted, data);
+        assert!(succ);
+        assert_eq!(should_store, store);
+        assert_eq!(&encrypted[..VERSION_LEN], stored_version);
+    }
+
+    fn assert_vec_round_trip(
+        data: &[u8],
+        stored_version: &str,
+        current_version: &str,
+        store: bool,
+    ) {
+        let encrypted = encrypt_vec_or_original(data, stored_version, MAX_LEN);
+        let (decrypted, succ, should_store) = decrypt_vec_or_original(&encrypted, current_version);
+        assert_eq!(decrypted, data);
+        assert!(succ);
+        assert_eq!(should_store, store);
+        assert_eq!(&encrypted[..VERSION_LEN], stored_version.as_bytes());
+    }
 
     #[test]
-    fn test() {
-        use super::*;
-        use rand::{thread_rng, Rng};
-        use std::time::Instant;
+    fn test_version_02_round_trip_and_reencrypt_flags() {
+        assert_str_round_trip("1ü1111", VERSION_02_USER, VERSION_02_USER, false);
+        assert_str_round_trip("1ü1111", VERSION_02_USER, "99", true);
 
-        let version = "00";
-        let max_len = 128;
+        let data = "1ü1111".as_bytes().to_vec();
+        assert_vec_round_trip(&data, VERSION_02_USER, VERSION_02_USER, false);
+        assert_vec_round_trip(&data, VERSION_02_USER, "99", true);
+    }
 
-        println!("test str");
-        let data = "1ü1111";
-        let encrypted = encrypt_str_or_original(data, version, max_len);
-        let (decrypted, succ, store) = decrypt_str_or_original(&encrypted, version);
-        println!("data: {data}");
-        println!("encrypted: {encrypted}");
-        println!("decrypted: {decrypted}");
-        assert_eq!(data, decrypted);
-        assert_eq!(version, &encrypted[..2]);
-        assert!(succ);
-        assert!(!store);
-        let (_, _, store) = decrypt_str_or_original(&encrypted, "99");
-        assert!(store);
-        assert!(!decrypt_str_or_original(&decrypted, version).1);
+    #[test]
+    fn test_duplicate_encryption_is_noop() {
+        let encrypted_str = encrypt_str_or_original("1ü1111", VERSION_02_USER, MAX_LEN);
         assert_eq!(
-            encrypt_str_or_original(&encrypted, version, max_len),
-            encrypted
+            encrypt_str_or_original(&encrypted_str, VERSION_02_USER, MAX_LEN),
+            encrypted_str
         );
 
-        println!("test vec");
-        let data: Vec<u8> = "1ü1111".as_bytes().to_vec();
-        let encrypted = encrypt_vec_or_original(&data, version, max_len);
-        let (decrypted, succ, store) = decrypt_vec_or_original(&encrypted, version);
-        println!("data: {data:?}");
-        println!("encrypted: {encrypted:?}");
-        println!("decrypted: {decrypted:?}");
-        assert_eq!(data, decrypted);
-        assert_eq!(version.as_bytes(), &encrypted[..2]);
-        assert!(!store);
-        assert!(succ);
-        let (_, _, store) = decrypt_vec_or_original(&encrypted, "99");
-        assert!(store);
-        assert!(!decrypt_vec_or_original(&decrypted, version).1);
+        let encrypted_vec = encrypt_vec_or_original("1ü1111".as_bytes(), VERSION_02_USER, MAX_LEN);
         assert_eq!(
-            encrypt_vec_or_original(&encrypted, version, max_len),
-            encrypted
+            encrypt_vec_or_original(&encrypted_vec, VERSION_02_USER, MAX_LEN),
+            encrypted_vec
+        );
+    }
+
+    #[test]
+    fn test_plaintext_inputs_remain_plaintext() {
+        let version_prefixed_str = VERSION_02_USER.to_string() + "Hello World";
+        let (decrypted, succ, store) =
+            decrypt_str_or_original(&version_prefixed_str, VERSION_02_USER);
+        assert_eq!(decrypted, version_prefixed_str);
+        assert!(!succ);
+        assert!(store);
+
+        let version_prefixed_vec = vec![
+            VERSION_02_USER.as_bytes()[0],
+            VERSION_02_USER.as_bytes()[1],
+            1,
+            2,
+            3,
+            4,
+        ];
+        let (decrypted, succ, store) =
+            decrypt_vec_or_original(&version_prefixed_vec, VERSION_02_USER);
+        assert_eq!(decrypted, version_prefixed_vec);
+        assert!(!succ);
+        assert!(store);
+
+        assert_eq!(
+            decrypt_str_or_original("1ü1111", VERSION_02_USER).0,
+            "1ü1111"
+        );
+        assert_eq!(
+            decrypt_vec_or_original("1ü1111".as_bytes(), VERSION_02_USER).0,
+            "1ü1111".as_bytes()
+        );
+        assert_eq!(
+            decrypt_str_or_original("", VERSION_02_USER),
+            ("".to_owned(), false, false)
+        );
+        assert_eq!(
+            decrypt_vec_or_original(&[], VERSION_02_USER),
+            (Vec::<u8>::new(), false, false)
+        );
+    }
+
+    #[test]
+    fn test_empty_inputs_do_not_encrypt_or_decrypt() {
+        assert_eq!(
+            encrypt_str_or_original("", VERSION_00_UUID, MAX_LEN),
+            "".to_owned()
+        );
+        assert_eq!(
+            encrypt_str_or_original("", VERSION_02_USER, MAX_LEN),
+            "".to_owned()
+        );
+        assert_eq!(
+            encrypt_vec_or_original(&[], VERSION_00_UUID, MAX_LEN),
+            Vec::<u8>::new()
+        );
+        assert_eq!(
+            encrypt_vec_or_original(&[], VERSION_02_USER, MAX_LEN),
+            Vec::<u8>::new()
         );
 
-        println!("test original");
-        let data = version.to_string() + "Hello World";
-        let (decrypted, succ, store) = decrypt_str_or_original(&data, version);
-        assert_eq!(data, decrypted);
-        assert!(store);
-        assert!(!succ);
-        let verbytes = version.as_bytes();
-        let data: Vec<u8> = vec![verbytes[0], verbytes[1], 1, 2, 3, 4, 5, 6];
-        let (decrypted, succ, store) = decrypt_vec_or_original(&data, version);
-        assert_eq!(data, decrypted);
-        assert!(store);
-        assert!(!succ);
-        let (_, succ, store) = decrypt_str_or_original("", version);
-        assert!(!store);
-        assert!(!succ);
-        let (_, succ, store) = decrypt_vec_or_original(&[], version);
-        assert!(!store);
-        assert!(!succ);
-        let data = "1ü1111";
-        assert_eq!(decrypt_str_or_original(data, version).0, data);
-        let data: Vec<u8> = "1ü1111".as_bytes().to_vec();
-        assert_eq!(decrypt_vec_or_original(&data, version).0, data);
+        assert_eq!(
+            decrypt_str_or_original("", VERSION_00_UUID),
+            ("".to_owned(), false, false)
+        );
+        assert_eq!(
+            decrypt_str_or_original("", VERSION_02_USER),
+            ("".to_owned(), false, false)
+        );
+        assert_eq!(
+            decrypt_vec_or_original(&[], VERSION_00_UUID),
+            (Vec::<u8>::new(), false, false)
+        );
+        assert_eq!(
+            decrypt_vec_or_original(&[], VERSION_02_USER),
+            (Vec::<u8>::new(), false, false)
+        );
+    }
 
-        // Base64-shaped "00" prefixed values shorter than MACBYTES are treated
-        // as original/plain values and should be stored.
-        let data = "00YWJjZA==";
-        let (decrypted, succ, store) = decrypt_str_or_original(data, version);
-        assert_eq!(decrypted, data);
-        assert!(!succ);
-        assert!(store);
-        let data = b"00YWJjZA==".to_vec();
-        let (decrypted, succ, store) = decrypt_vec_or_original(&data, version);
-        assert_eq!(decrypted, data);
+    #[test]
+    fn test_version_only_inputs_remain_plaintext() {
+        for version in [VERSION_00_UUID, VERSION_02_USER] {
+            assert_eq!(
+                decrypt_str_or_original(version, VERSION_02_USER),
+                (version.to_owned(), false, true)
+            );
+            assert_eq!(
+                decrypt_vec_or_original(version.as_bytes(), VERSION_02_USER),
+                (version.as_bytes().to_vec(), false, true)
+            );
+        }
+    }
+
+    #[test]
+    fn test_encrypted_like_but_undecryptable_values_do_not_loop_store() {
+        let short_base64 = "00YWJjZA==";
+        let (decrypted, succ, store) = decrypt_str_or_original(short_base64, VERSION_02_USER);
+        assert_eq!(decrypted, short_base64);
         assert!(!succ);
         assert!(store);
 
-        // When decoded length reaches MACBYTES, it is treated as encrypted-like
-        // and should not trigger repeated store.
+        let short_base64 = b"00YWJjZA==".to_vec();
+        let (decrypted, succ, store) = decrypt_vec_or_original(&short_base64, VERSION_02_USER);
+        assert_eq!(decrypted, short_base64);
+        assert!(!succ);
+        assert!(store);
+
         let exact_mac = vec![0u8; sodiumoxide::crypto::secretbox::MACBYTES];
         let exact_mac_b64 =
             sodiumoxide::base64::encode(&exact_mac, sodiumoxide::base64::Variant::Original);
-        let data = format!("00{exact_mac_b64}");
-        let (_, succ, store) = decrypt_str_or_original(&data, version);
-        assert!(!succ);
-        assert!(!store);
-        let data = data.into_bytes();
-        let (_, succ, store) = decrypt_vec_or_original(&data, version);
-        assert!(!succ);
-        assert!(!store);
-
-        println!("test speed");
-        let test_speed = |len: usize, name: &str| {
-            let mut data: Vec<u8> = vec![];
-            let mut rng = thread_rng();
-            for _ in 0..len {
-                data.push(rng.gen_range(0..255));
-            }
-            let start: Instant = Instant::now();
-            let encrypted = encrypt_vec_or_original(&data, version, len);
-            assert_ne!(data, decrypted);
-            let t1 = start.elapsed();
-            let start = Instant::now();
-            let (decrypted, _, _) = decrypt_vec_or_original(&encrypted, version);
-            let t2 = start.elapsed();
-            assert_eq!(data, decrypted);
-            println!("{name}");
-            println!("encrypt:{:?}, decrypt:{:?}", t1, t2);
-
-            let start: Instant = Instant::now();
-            let encrypted = base64::encode(&data, base64::Variant::Original);
-            let t1 = start.elapsed();
-            let start = Instant::now();
-            let decrypted = base64::decode(&encrypted, base64::Variant::Original).unwrap();
-            let t2 = start.elapsed();
-            assert_eq!(data, decrypted);
-            println!("base64, encrypt:{:?}, decrypt:{:?}", t1, t2,);
-        };
-        test_speed(128, "128");
-        test_speed(1024, "1k");
-        test_speed(1024 * 1024, "1M");
-        test_speed(10 * 1024 * 1024, "10M");
-        test_speed(100 * 1024 * 1024, "100M");
+        let encrypted_like = format!("00{exact_mac_b64}");
+        assert_eq!(
+            decrypt_str_or_original(&encrypted_like, VERSION_02_USER),
+            (encrypted_like.clone(), false, false)
+        );
+        assert_eq!(
+            decrypt_vec_or_original(encrypted_like.as_bytes(), VERSION_02_USER),
+            (encrypted_like.into_bytes(), false, false)
+        );
     }
 
     #[test]
@@ -378,40 +568,51 @@ mod test {
         use sodiumoxide::crypto::secretbox;
 
         // Empty data should not be considered encrypted
-        assert!(!is_encrypted(b""));
-        assert!(!is_encrypted(b"0"));
-        assert!(!is_encrypted(b"00"));
+        assert!(!is_encrypted(b"", true));
+        assert!(!is_encrypted(b"0", true));
+        assert!(!is_encrypted(b"00", true));
+        assert!(!is_encrypted(b"", false));
+        assert!(!is_encrypted(b"0", false));
+        assert!(!is_encrypted(b"00", false));
 
         // Data without "00" prefix should not be considered encrypted
-        assert!(!is_encrypted(b"01abcd"));
-        assert!(!is_encrypted(b"99abcd"));
-        assert!(!is_encrypted(b"hello world"));
+        assert!(!is_encrypted(b"01abcd", true));
+        assert!(!is_encrypted(b"99abcd", true));
+        assert!(!is_encrypted(b"hello world", true));
+        assert!(!is_encrypted(b"01abcd", false));
+        assert!(!is_encrypted(b"99abcd", false));
+        assert!(!is_encrypted(b"hello world", false));
 
         // Data with "00" prefix but invalid base64 should not be considered encrypted
-        assert!(!is_encrypted(b"00!!!invalid base64!!!"));
-        assert!(!is_encrypted(b"00@#$%"));
+        assert!(!is_encrypted(b"00!!!invalid base64!!!", true));
+        assert!(!is_encrypted(b"00@#$%", true));
+        assert!(!is_encrypted(b"00!!!invalid base64!!!", false));
+        assert!(!is_encrypted(b"00@#$%", false));
 
         // Data with "00" prefix and valid base64 but shorter than MACBYTES is not encrypted
-        assert!(!is_encrypted(b"00YWJjZA==")); // "abcd" in base64
-        assert!(!is_encrypted(b"00SGVsbG8gV29ybGQ=")); // "Hello World" in base64
+        assert!(!is_encrypted(b"00YWJjZA==", true)); // "abcd" in base64
+        assert!(!is_encrypted(b"00SGVsbG8gV29ybGQ=", true)); // "Hello World" in base64
+        assert!(!is_encrypted(b"00YWJjZA==", false));
+        assert!(!is_encrypted(b"00SGVsbG8gV29ybGQ=", false));
 
         // Data with "00" prefix and valid base64 with decoded len == MACBYTES is considered encrypted
         let exact_mac = vec![0u8; secretbox::MACBYTES];
         let exact_mac_b64 = encode(&exact_mac, Variant::Original);
         let exact_mac_candidate = format!("00{exact_mac_b64}");
-        assert!(is_encrypted(exact_mac_candidate.as_bytes()));
+        assert!(is_encrypted(exact_mac_candidate.as_bytes(), true));
+        assert!(is_encrypted(exact_mac_candidate.as_bytes(), false));
 
         // Real encrypted data should be detected
-        let version = "00";
+        let version_uuid = VERSION_00_UUID;
         let max_len = 128;
-        let encrypted_str = encrypt_str_or_original("1", version, max_len);
-        assert!(is_encrypted(encrypted_str.as_bytes()));
-        let encrypted_vec = encrypt_vec_or_original(b"1", version, max_len);
-        assert!(is_encrypted(&encrypted_vec));
+        let encrypted_str = encrypt_str_or_original("1", version_uuid, max_len);
+        assert!(is_encrypted(encrypted_str.as_bytes(), true));
+        let encrypted_vec = encrypt_vec_or_original(b"1", version_uuid, max_len);
+        assert!(is_encrypted(&encrypted_vec, false));
 
         // Original unencrypted data should not be detected as encrypted
-        assert!(!is_encrypted(b"1"));
-        assert!(!is_encrypted("1".as_bytes()));
+        assert!(!is_encrypted(b"1", true));
+        assert!(!is_encrypted("1".as_bytes(), false));
     }
 
     #[test]
@@ -420,35 +621,95 @@ mod test {
         use sodiumoxide::base64::{decode, Variant};
         use sodiumoxide::crypto::secretbox;
 
-        let version = "00";
+        let version_user_scope = VERSION_02_USER;
         let max_len = 128;
 
-        let encrypted_str = encrypt_str_or_original("1", version, max_len);
+        let encrypted_str = encrypt_str_or_original("1", version_user_scope, max_len);
         let decoded = decode(&encrypted_str.as_bytes()[VERSION_LEN..], Variant::Original).unwrap();
         assert!(
             decoded.len() >= secretbox::MACBYTES,
             "decoded encrypted payload must be at least MACBYTES"
         );
 
-        let encrypted_vec = encrypt_vec_or_original(b"1", version, max_len);
-        let decoded = decode(&encrypted_vec[VERSION_LEN..], Variant::Original).unwrap();
+        let encrypted_vec = encrypt_vec_or_original(b"1", version_user_scope, max_len);
         assert!(
-            decoded.len() >= secretbox::MACBYTES,
-            "decoded encrypted payload must be at least MACBYTES"
+            encrypted_vec[VERSION_LEN..].len() >= secretbox::MACBYTES,
+            "encrypted vec payload must be at least MACBYTES"
         );
     }
 
-    // Test decryption fallback when data was encrypted with key_pair but decryption tries machine_uid first
+    #[test]
+    fn test_decrypt_str_or_original_non_ascii_prefix_does_not_panic() {
+        use super::*;
+
+        let data = "中a";
+        let (decrypted, succ, store) = decrypt_str_or_original(data, VERSION_02_USER);
+        assert_eq!(decrypted, data);
+        assert!(!succ);
+        assert!(store);
+    }
+
+    #[test]
+    fn test_version_02_magic_header_detection() {
+        use super::*;
+
+        let payload = b"payload".to_vec();
+        assert!(!crate::secret_store::user_data_has_magic_header(&payload));
+        assert!(!is_encrypted(
+            format!(
+                "{VERSION_02_USER}{}",
+                base64::encode(&payload, base64::Variant::Original)
+            )
+            .as_bytes(),
+            true
+        ));
+
+        let current_payload = crate::secret_store::user_data_add_magic_header(payload.clone());
+        assert!(crate::secret_store::user_data_has_magic_header(
+            &current_payload
+        ));
+
+        let encoded = base64::encode(&current_payload, base64::Variant::Original);
+        let versioned = format!("{VERSION_02_USER}{encoded}");
+        assert!(is_encrypted(versioned.as_bytes(), true));
+        assert!(!should_store_after_decrypt(
+            VERSION_02_USER,
+            &payload,
+            VERSION_02_USER,
+            true
+        ));
+    }
+
+    #[test]
+    fn test_version_02_encrypted_payload_has_magic_header() {
+        use super::*;
+        use sodiumoxide::base64::{decode, Variant};
+
+        let encrypted = encrypt_str_or_original("1", VERSION_02_USER, 128);
+        let payload = decode(&encrypted.as_bytes()[VERSION_LEN..], Variant::Original).unwrap();
+        assert!(crate::secret_store::user_data_has_magic_header(&payload));
+    }
+
+    #[test]
+    fn test_version_02_vec_uses_raw_payload() {
+        use super::*;
+
+        let encrypted = encrypt_vec_or_original(b"1", VERSION_02_USER, 128);
+        let payload = &encrypted[VERSION_LEN..];
+        assert!(crate::secret_store::user_data_has_magic_header(payload));
+        assert!(is_encrypted(&encrypted, false));
+    }
+
     #[test]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn test_decrypt_with_pk_fallback() {
+        use super::*;
         use sodiumoxide::crypto::secretbox;
         use std::convert::TryInto;
 
         let uuid = crate::get_uuid();
         let pk = crate::config::Config::get_key_pair().1;
 
-        // Ensure uuid != pk, otherwise fallback branch won't be tested
         if uuid == pk {
             eprintln!("skip: uuid == pk, fallback branch won't be tested");
             return;
@@ -457,18 +718,24 @@ mod test {
         let data = b"test password 123";
         let nonce = secretbox::Nonce([0; secretbox::NONCEBYTES]);
 
-        // Encrypt with pk (simulating machine_uid failure during encryption)
         let mut pk_keybuf = pk;
         pk_keybuf.resize(secretbox::KEYBYTES, 0);
         let pk_key = secretbox::Key(pk_keybuf.try_into().unwrap());
         let encrypted = secretbox::seal(data, &nonce, &pk_key);
 
-        // Decrypt using symmetric_crypt (should fallback to pk since uuid differs)
-        let decrypted = super::symmetric_crypt(&encrypted, false);
+        let decrypted = symmetric_crypt_00_uuid(&encrypted, false);
         assert!(
             decrypted.is_ok(),
             "Decryption with pk fallback should succeed"
         );
         assert_eq!(decrypted.unwrap(), data);
+    }
+
+    #[test]
+    fn test_version_00_cross_version_compatibility() {
+        assert_str_round_trip("old-to-new", VERSION_00_UUID, VERSION_02_USER, true);
+        assert_str_round_trip("new-to-old", VERSION_00_UUID, VERSION_00_UUID, false);
+        assert_vec_round_trip(b"old-to-new-vec", VERSION_00_UUID, VERSION_02_USER, true);
+        assert_vec_round_trip(b"new-to-old-vec", VERSION_00_UUID, VERSION_00_UUID, false);
     }
 }

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,0 +1,18 @@
+use crate::secret_store::{SecretStoreError, SecretStoreResult};
+
+const ANDROID_SECRET_STORE_DISABLED: &str =
+    "Android secret store is disabled; Android uses version 00 UUID-scoped encryption";
+
+pub fn load_secret(_service: &str, _account: &str) -> SecretStoreResult<Vec<u8>> {
+    Err(SecretStoreError::backend_message(
+        "Android secret store is unavailable",
+        ANDROID_SECRET_STORE_DISABLED,
+    ))
+}
+
+pub fn store_secret(_service: &str, _account: &str, _secret: &[u8]) -> SecretStoreResult<()> {
+    Err(SecretStoreError::backend_message(
+        "Android secret store is unavailable",
+        ANDROID_SECRET_STORE_DISABLED,
+    ))
+}

--- a/src/platform/apple.rs
+++ b/src/platform/apple.rs
@@ -1,0 +1,54 @@
+use crate::secret_store::{SecretStoreError, SecretStoreResult};
+use security_framework::passwords::{generic_password, set_generic_password, PasswordOptions};
+
+// errSecItemNotFound from Apple Security Framework (defined in SecBase.h)
+// https://developer.apple.com/documentation/security/1542001-security_framework_result_codes
+// https://github.com/apple-oss-distributions/Security/blob/db15acbe6a7f257a859ad9a3bb86097bfe0679d9/base/SecBase.h#L353
+// Chromium similarly only special-cases `errSecItemNotFound`; other keychain
+// errors are logged and returned to the caller unchanged:
+// https://chromium.googlesource.com/chromium/src/+/main/components/os_crypt/common/keychain_password_mac.mm#97
+const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+// In the normal same-signing app flow this should not happen. Apple documents
+// that permissions can be lost after corruption or upgrades:
+// https://support.apple.com/en-lk/guide/keychain-access/kyca1331/mac
+// If the user manually denies the request, treat it as sticky and stop reading
+// the keychain again after recording the failure.
+const ERR_SEC_USER_CANCELED: i32 = -128;
+
+pub(crate) fn map_keychain_result<T>(
+    result: security_framework::base::Result<T>,
+    context: &'static str,
+) -> SecretStoreResult<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(err) if err.code() == ERR_SEC_ITEM_NOT_FOUND => Err(SecretStoreError::NotFound),
+        Err(err) if err.code() == ERR_SEC_USER_CANCELED => {
+            Err(SecretStoreError::user_canceled(context, err))
+        }
+        Err(err) => Err(SecretStoreError::backend(context, err)),
+    }
+}
+
+pub fn load_secret_keychain_generic(service: &str, account: &str) -> SecretStoreResult<Vec<u8>> {
+    // https://developer.apple.com/documentation/security/secitemcopymatching
+    // Chromium: https://chromium.googlesource.com/chromium/src/+/main/components/os_crypt/common/keychain_password_mac.mm
+    map_keychain_result(
+        generic_password(PasswordOptions::new_generic_password(service, account)),
+        "failed to read secret from Apple generic keychain",
+    )
+}
+
+pub fn store_secret_keychain_generic(
+    service: &str,
+    account: &str,
+    secret: &[u8],
+) -> SecretStoreResult<()> {
+    // https://developer.apple.com/documentation/security/secitemadd
+    // https://developer.apple.com/documentation/security/secitemupdate
+    // Chromium: https://chromium.googlesource.com/chromium/src/+/main/components/os_crypt/common/keychain_password_mac.mm
+    map_keychain_result(
+        set_generic_password(service, account, secret),
+        "failed to write secret to Apple generic keychain",
+    )?;
+    Ok(())
+}

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,0 +1,9 @@
+use crate::secret_store::SecretStoreResult;
+
+pub fn load_secret(service: &str, account: &str) -> SecretStoreResult<Vec<u8>> {
+    crate::platform::apple::load_secret_keychain_generic(service, account)
+}
+
+pub fn store_secret(service: &str, account: &str, secret: &[u8]) -> SecretStoreResult<()> {
+    crate::platform::apple::store_secret_keychain_generic(service, account, secret)
+}

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,8 +1,20 @@
+use crate::secret_store::{SecretStoreError, SecretStoreResult};
 use crate::ResultType;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use dbus_secret_service::{EncryptionType, Item, SecretService};
+use sha2::{Digest, Sha256};
 use std::{
     collections::HashMap,
+    os::fd::AsFd,
     path::{Path, PathBuf},
     process::Command,
+    sync::mpsc::{sync_channel, RecvTimeoutError},
+    time::Duration,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::UnixStream,
 };
 use users::{get_current_uid, get_user_by_uid, os::unix::UserExt};
 
@@ -495,6 +507,200 @@ pub fn get_home_dir_trusted() -> Option<PathBuf> {
             None
         }
     }
+}
+
+const FLATPAK_SECRET_DERIVE_INFO: &[u8] = b"hbb-common-flatpak-secret-v1";
+const FLATPAK_PORTAL_TIMEOUT_MS: u64 = 3_000;
+const FLATPAK_PORTAL_RESULT_TIMEOUT_MS: u64 = FLATPAK_PORTAL_TIMEOUT_MS + 1_000;
+
+#[inline]
+fn is_flatpak() -> bool {
+    PathBuf::from("/.flatpak-info").exists()
+}
+
+// Keep the Linux secret-store API synchronous even though the portal client is async.
+fn run_flatpak_portal_task<T, F, Fut>(task: F) -> SecretStoreResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = SecretStoreResult<T>> + 'static,
+{
+    let (tx, rx) = sync_channel(1);
+    std::thread::spawn(move || {
+        let result = run_flatpak_portal_task_async(task);
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(Duration::from_millis(FLATPAK_PORTAL_RESULT_TIMEOUT_MS)) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(SecretStoreError::backend_message(
+            "timed out waiting for xdg-desktop-portal secret",
+            format!(
+                "portal worker did not finish within {} ms",
+                FLATPAK_PORTAL_RESULT_TIMEOUT_MS
+            ),
+        )),
+        Err(RecvTimeoutError::Disconnected) => Err(SecretStoreError::backend_message(
+            "failed to receive xdg-desktop-portal secret worker result",
+            "portal worker exited without sending a result",
+        )),
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn run_flatpak_portal_task_async<T, F, Fut>(task: F) -> SecretStoreResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = SecretStoreResult<T>> + 'static,
+{
+    match crate::timeout(FLATPAK_PORTAL_TIMEOUT_MS, task()).await {
+        Ok(result) => result,
+        Err(_) => Err(SecretStoreError::backend_message(
+            "timed out waiting for xdg-desktop-portal secret",
+            format!("portal request exceeded {} ms", FLATPAK_PORTAL_TIMEOUT_MS),
+        )),
+    }
+}
+
+fn retrieve_flatpak_portal_secret() -> SecretStoreResult<Vec<u8>> {
+    run_flatpak_portal_task(|| async {
+        // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html
+        ashpd::desktop::secret::retrieve().await.map_err(|err| {
+            SecretStoreError::backend("failed to retrieve xdg-desktop-portal secret", err)
+        })
+    })
+}
+
+// Flatpak uses a stable per-app secret from the portal.
+// Derive a 32-byte app key instead of persisting extra data.
+fn derive_flatpak_secret(portal_secret: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(FLATPAK_SECRET_DERIVE_INFO);
+    hasher.update(portal_secret);
+    hasher.finalize().to_vec()
+}
+
+fn load_flatpak_secret_store_key() -> SecretStoreResult<Vec<u8>> {
+    let portal_secret = retrieve_flatpak_portal_secret()?;
+    Ok(derive_flatpak_secret(&portal_secret))
+}
+
+fn store_flatpak_secret_store_key(secret: &[u8]) -> SecretStoreResult<()> {
+    let expected = load_flatpak_secret_store_key()?;
+    if secret == expected.as_slice() {
+        Ok(())
+    } else {
+        Err(SecretStoreError::backend_message(
+            "Flatpak secret backend is read-only",
+            "requested secret does not match the portal-derived secret",
+        ))
+    }
+}
+
+// KWallet requires UTF-8, so encode secrets as base64.
+fn encode_secret_service_secret(secret: &[u8]) -> Vec<u8> {
+    BASE64_STANDARD.encode(secret).into_bytes()
+}
+
+fn decode_secret_service_secret(secret: Vec<u8>) -> SecretStoreResult<Vec<u8>> {
+    BASE64_STANDARD.decode(secret).map_err(|err| {
+        SecretStoreError::invalid(
+            "failed to decode Linux Secret Service base64 secret",
+            err.to_string(),
+        )
+    })
+}
+
+pub fn load_secret_store_key(service: &str, account: &str) -> SecretStoreResult<Vec<u8>> {
+    // https://specifications.freedesktop.org/secret-service/latest/
+    let attrs = HashMap::from([("service", service), ("account", account)]);
+    let ss = SecretService::connect(EncryptionType::Dh).map_err(|err| {
+        SecretStoreError::backend("failed to connect to Linux Secret Service", err)
+    })?;
+    let search = ss.search_items(attrs).map_err(|err| {
+        SecretStoreError::backend("failed to search Linux Secret Service items", err)
+    })?;
+    if !search.locked.is_empty() {
+        let item_refs: Vec<&Item> = search.locked.iter().collect();
+        ss.unlock_all(item_refs.as_slice()).map_err(|err| {
+            SecretStoreError::backend("failed to unlock Linux Secret Service items", err)
+        })?;
+    }
+
+    let mut saw_item = false;
+    let mut last_invalid = None;
+    let mut last_error = None;
+    for item in search.unlocked.iter().chain(search.locked.iter()) {
+        saw_item = true;
+        match item.get_secret() {
+            Ok(secret) => match decode_secret_service_secret(secret) {
+                Ok(secret) => return Ok(secret),
+                Err(err) => last_invalid = Some(err),
+            },
+            Err(err) => last_error = Some(err.to_string()),
+        }
+    }
+
+    if let Some(err) = last_invalid {
+        Err(err)
+    } else if saw_item {
+        Err(SecretStoreError::backend_message(
+            "failed to read secret from Linux Secret Service",
+            last_error.unwrap_or_else(|| "unknown secret read error".to_owned()),
+        ))
+    } else {
+        Err(SecretStoreError::NotFound)
+    }
+}
+
+pub fn store_secret_store_key(
+    service: &str,
+    account: &str,
+    secret: &[u8],
+) -> SecretStoreResult<()> {
+    // https://specifications.freedesktop.org/secret-service/latest/
+    let attrs = HashMap::from([("service", service), ("account", account)]);
+    let ss = SecretService::connect(EncryptionType::Dh).map_err(|err| {
+        SecretStoreError::backend("failed to connect to Linux Secret Service", err)
+    })?;
+    let collection = ss.get_default_collection().map_err(|err| {
+        SecretStoreError::backend("failed to get Linux Secret Service collection", err)
+    })?;
+    if collection.is_locked().map_err(|err| {
+        SecretStoreError::backend("failed to query Linux Secret Service lock state", err)
+    })? {
+        collection.unlock().map_err(|err| {
+            SecretStoreError::backend("failed to unlock Linux Secret Service collection", err)
+        })?;
+    }
+    let label = format!("{service} {account}");
+    let encoded_secret = encode_secret_service_secret(secret);
+    collection
+        .create_item(&label, attrs, &encoded_secret, true, "text/plain")
+        .map_err(|err| {
+            SecretStoreError::backend("failed to create Linux Secret Service item", err)
+        })?;
+    Ok(())
+}
+
+/// Use Secret Service as the Linux secret backend outside Flatpak.
+///
+/// Do not use the kernel keyutils persistent keyring for RustDesk's master key:
+/// it is not durable and can disappear, causing previously encrypted config to become unreadable.
+pub fn load_secret(service: &str, account: &str) -> SecretStoreResult<Vec<u8>> {
+    if is_flatpak() {
+        let _ = (service, account);
+        return load_flatpak_secret_store_key();
+    }
+    load_secret_store_key(service, account)
+}
+
+pub fn store_secret(service: &str, account: &str, secret: &[u8]) -> SecretStoreResult<()> {
+    if is_flatpak() {
+        let _ = (service, account);
+        return store_flatpak_secret_store_key(secret);
+    }
+    store_secret_store_key(service, account, secret)
 }
 
 #[cfg(test)]

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,3 +1,4 @@
+use crate::secret_store::SecretStoreResult;
 use crate::ResultType;
 use osascript;
 use serde_derive::{Deserialize, Serialize};
@@ -52,4 +53,12 @@ pub fn alert(
         buttons,
     })?;
     Ok(result.button)
+}
+
+pub fn load_secret(service: &str, account: &str) -> SecretStoreResult<Vec<u8>> {
+    crate::platform::apple::load_secret_keychain_generic(service, account)
+}
+
+pub fn store_secret(service: &str, account: &str, secret: &[u8]) -> SecretStoreResult<()> {
+    crate::platform::apple::store_secret_keychain_generic(service, account, secret)
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,11 +1,30 @@
+#[cfg(target_os = "android")]
+pub mod android;
+#[cfg(target_os = "android")]
+pub(crate) use android::*;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub mod apple;
+
+#[cfg(target_os = "ios")]
+pub mod ios;
+#[cfg(target_os = "ios")]
+pub(crate) use ios::*;
+
 #[cfg(target_os = "linux")]
 pub mod linux;
+#[cfg(target_os = "linux")]
+pub(crate) use linux::*;
 
 #[cfg(target_os = "macos")]
 pub mod macos;
+#[cfg(target_os = "macos")]
+pub(crate) use macos::*;
 
 #[cfg(target_os = "windows")]
 pub mod windows;
+#[cfg(target_os = "windows")]
+pub(crate) use windows::*;
 
 #[cfg(not(debug_assertions))]
 use crate::{config::Config, log};

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,5 +1,8 @@
+use crate::secret_store::{SecretStoreError, SecretStoreResult};
 use std::{
     collections::VecDeque,
+    convert::TryInto,
+    fs,
     sync::{Arc, Mutex},
     time::Instant,
 };
@@ -19,6 +22,13 @@ use winapi::{
             HANDLE, OSVERSIONINFOEXW, VER_BUILDNUMBER, VER_GREATER_EQUAL, VER_MAJORVERSION,
             VER_MINORVERSION, VER_SERVICEPACKMAJOR, VER_SERVICEPACKMINOR,
         },
+    },
+};
+use windows::{
+    core::PCWSTR,
+    Win32::{
+        Foundation::{LocalFree, HLOCAL},
+        Security::Cryptography::{CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB},
     },
 };
 
@@ -195,4 +205,65 @@ pub fn is_windows_version_or_greater(
     };
 
     result == TRUE
+}
+
+pub(crate) fn dpapi_encrypt_bytes(data: &[u8]) -> SecretStoreResult<Vec<u8>> {
+    // https://learn.microsoft.com/en-us/windows/win32/api/dpapi/nf-dpapi-cryptprotectdata
+    let in_blob = CRYPT_INTEGER_BLOB {
+        cbData: data.len().try_into().map_err(|_| {
+            SecretStoreError::backend_message(
+                "failed to prepare Windows DPAPI plaintext blob",
+                "input is too large for CRYPT_INTEGER_BLOB",
+            )
+        })?,
+        pbData: data.as_ptr() as *mut u8,
+    };
+    let mut out_blob = CRYPT_INTEGER_BLOB::default();
+    unsafe { CryptProtectData(&in_blob, PCWSTR::null(), None, None, None, 0, &mut out_blob) }
+        .map_err(|err| SecretStoreError::backend("failed to encrypt Windows DPAPI payload", err))?;
+    let encrypted = blob_to_vec(&out_blob)?;
+    free_local_buffer(out_blob.pbData);
+    Ok(encrypted)
+}
+
+pub(crate) fn dpapi_decrypt_bytes(data: &[u8]) -> SecretStoreResult<Vec<u8>> {
+    // https://learn.microsoft.com/en-us/windows/win32/api/dpapi/nf-dpapi-cryptunprotectdata
+    let in_blob = CRYPT_INTEGER_BLOB {
+        cbData: data.len().try_into().map_err(|_| {
+            SecretStoreError::backend_message(
+                "failed to prepare Windows DPAPI ciphertext blob",
+                "input is too large for CRYPT_INTEGER_BLOB",
+            )
+        })?,
+        pbData: data.as_ptr() as *mut u8,
+    };
+    let mut out_blob = CRYPT_INTEGER_BLOB::default();
+    unsafe { CryptUnprotectData(&in_blob, None, None, None, None, 0, &mut out_blob) }
+        .map_err(|err| SecretStoreError::backend("failed to decrypt Windows DPAPI payload", err))?;
+    let decrypted = blob_to_vec(&out_blob)?;
+    free_local_buffer(out_blob.pbData);
+    Ok(decrypted)
+}
+
+fn blob_to_vec(blob: &CRYPT_INTEGER_BLOB) -> SecretStoreResult<Vec<u8>> {
+    if blob.cbData == 0 {
+        return Ok(Vec::new());
+    }
+    if blob.pbData.is_null() {
+        Err(SecretStoreError::backend_message(
+            "failed to read Windows blob",
+            "blob pointer was null",
+        ))
+    } else {
+        Ok(unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize).to_vec() })
+    }
+}
+
+fn free_local_buffer(buffer: *mut u8) {
+    // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-localfree
+    if !buffer.is_null() {
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(buffer.cast())));
+        }
+    }
 }

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -1,0 +1,342 @@
+#[cfg(not(target_os = "windows"))]
+use crate::{
+    config::{self, APP_NAME},
+    log,
+};
+#[cfg(not(target_os = "windows"))]
+use once_cell::sync::OnceCell;
+
+const MASTER_KEY_LEN: usize = sodiumoxide::crypto::secretbox::KEYBYTES;
+#[cfg(not(target_os = "windows"))]
+const SAFE_STORAGE_SUFFIX: &str = " Safe Storage";
+const USER_DATA_MAGIC_HEADER: [u8; 16] = [
+    0xbe, 0xb6, 0x88, 0x39, 0x41, 0x15, 0x4b, 0xe7, 0x8d, 0x94, 0x10, 0x23, 0x59, 0x8f, 0x8b, 0x24,
+];
+
+#[cfg(not(target_os = "windows"))]
+static MASTER_KEY: OnceCell<Result<sodiumoxide::crypto::secretbox::Key, CachedSecretStoreError>> =
+    OnceCell::new();
+
+pub type SecretStoreResult<T> = Result<T, SecretStoreError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SecretStoreError {
+    #[error("secret not found")]
+    NotFound,
+    #[error("{context}: {message}")]
+    Invalid {
+        context: &'static str,
+        message: String,
+    },
+    #[error("{context}: user canceled")]
+    UserCanceled {
+        context: &'static str,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("{context}: {source}")]
+    Backend {
+        context: &'static str,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl SecretStoreError {
+    pub fn backend(context: &'static str, source: impl Into<anyhow::Error>) -> Self {
+        Self::Backend {
+            context,
+            source: source.into(),
+        }
+    }
+
+    pub fn backend_message(context: &'static str, message: impl Into<String>) -> Self {
+        Self::Backend {
+            context,
+            source: anyhow::Error::msg(message.into()),
+        }
+    }
+
+    pub fn invalid(context: &'static str, message: impl Into<String>) -> Self {
+        Self::Invalid {
+            context,
+            message: message.into(),
+        }
+    }
+
+    pub fn user_canceled(context: &'static str, source: impl Into<anyhow::Error>) -> Self {
+        Self::UserCanceled {
+            context,
+            source: source.into(),
+        }
+    }
+
+    pub(crate) fn is_user_canceled(&self) -> bool {
+        matches!(self, Self::UserCanceled { .. })
+    }
+}
+
+#[derive(Debug, Clone)]
+enum CachedSecretStoreError {
+    NotFound,
+    Invalid {
+        context: &'static str,
+        message: String,
+    },
+    UserCanceled {
+        context: &'static str,
+        message: String,
+    },
+    Backend {
+        context: &'static str,
+        message: String,
+    },
+}
+
+impl From<SecretStoreError> for CachedSecretStoreError {
+    fn from(err: SecretStoreError) -> Self {
+        match err {
+            SecretStoreError::NotFound => Self::NotFound,
+            SecretStoreError::Invalid { context, message } => Self::Invalid { context, message },
+            SecretStoreError::UserCanceled { context, source } => Self::UserCanceled {
+                context,
+                message: source.to_string(),
+            },
+            SecretStoreError::Backend { context, source } => Self::Backend {
+                context,
+                message: source.to_string(),
+            },
+        }
+    }
+}
+
+impl CachedSecretStoreError {
+    fn to_secret_store_error(&self) -> SecretStoreError {
+        match self {
+            Self::NotFound => SecretStoreError::NotFound,
+            Self::Invalid { context, message } => {
+                SecretStoreError::invalid(context, message.clone())
+            }
+            Self::UserCanceled { context, message } => {
+                SecretStoreError::user_canceled(context, anyhow::Error::msg(message.clone()))
+            }
+            Self::Backend { context, message } => {
+                SecretStoreError::backend_message(context, message.clone())
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_or_init_cached_secret<T, F>(
+    cache: &OnceCell<Result<T, CachedSecretStoreError>>,
+    init: F,
+) -> SecretStoreResult<&T>
+where
+    F: FnOnce() -> SecretStoreResult<T>,
+{
+    match cache.get_or_init(|| init().map_err(CachedSecretStoreError::from)) {
+        Ok(value) => Ok(value),
+        Err(err) => Err(err.to_secret_store_error()),
+    }
+}
+
+pub(crate) fn user_data_magic_header() -> &'static [u8] {
+    &USER_DATA_MAGIC_HEADER
+}
+
+pub(crate) fn user_data_has_magic_header(payload: &[u8]) -> bool {
+    payload.starts_with(user_data_magic_header())
+}
+
+pub(crate) fn user_data_add_magic_header(mut payload: Vec<u8>) -> Vec<u8> {
+    let mut out = user_data_magic_header().to_vec();
+    out.append(&mut payload);
+    out
+}
+
+pub(crate) fn user_data_strip_magic_header(payload: &[u8]) -> (&[u8], bool) {
+    if let Some(payload) = payload.strip_prefix(user_data_magic_header()) {
+        (payload, true)
+    } else {
+        (payload, false)
+    }
+}
+
+pub(crate) fn is_encrypted_user_data(payload: &[u8]) -> bool {
+    user_data_has_magic_header(payload)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn secretbox_encrypt_user_data_raw(
+    data: &[u8],
+) -> Result<Vec<u8>, crate::password_security::CryptError> {
+    use sodiumoxide::crypto::secretbox;
+
+    let key = master_secretbox_key()
+        .map_err(|_| crate::password_security::CryptError::EncryptionFailed)?;
+    let nonce = secretbox::gen_nonce();
+    let mut out = nonce.0.to_vec();
+    out.extend(secretbox::seal(data, &nonce, key));
+    Ok(out)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn secretbox_decrypt_user_data_raw(
+    data: &[u8],
+) -> Result<Vec<u8>, crate::password_security::CryptError> {
+    use sodiumoxide::crypto::secretbox;
+    use std::convert::TryInto;
+
+    if data.len() < secretbox_user_data_min_len() {
+        return Err(crate::password_security::CryptError::InvalidData);
+    }
+    let key = master_secretbox_key()
+        .map_err(|_| crate::password_security::CryptError::DecryptionFailed)?;
+    let nonce = secretbox::Nonce(
+        data[..secretbox::NONCEBYTES]
+            .try_into()
+            .map_err(|_| crate::password_security::CryptError::InvalidData)?,
+    );
+    secretbox::open(&data[secretbox::NONCEBYTES..], &nonce, key)
+        .map_err(|_| crate::password_security::CryptError::DecryptionFailed)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn secretbox_user_data_min_len() -> usize {
+    sodiumoxide::crypto::secretbox::NONCEBYTES + sodiumoxide::crypto::secretbox::MACBYTES
+}
+
+#[cfg(not(target_os = "windows"))]
+fn master_secretbox_key() -> SecretStoreResult<&'static sodiumoxide::crypto::secretbox::Key> {
+    // Cache key load/failure to avoid repeatedly blocking on broken secret backend.
+    get_or_init_cached_secret(&MASTER_KEY, load_or_create_master_secretbox_key)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn should_regenerate_master_secret(err: &SecretStoreError) -> bool {
+    matches!(
+        err,
+        SecretStoreError::NotFound | SecretStoreError::Invalid { .. }
+    )
+}
+
+#[cfg(not(target_os = "windows"))]
+fn current_secret_store_names(app_name: &str) -> (String, String) {
+    (
+        format!("{app_name}{SAFE_STORAGE_SUFFIX}"),
+        app_name.to_owned(),
+    )
+}
+
+#[cfg(not(target_os = "windows"))]
+fn should_mark_skip_load(err: &SecretStoreError) -> bool {
+    err.is_user_canceled()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn load_or_create_master_secretbox_key() -> SecretStoreResult<sodiumoxide::crypto::secretbox::Key> {
+    use std::convert::TryInto;
+
+    if config::SecretStatus::load().should_skip_load() {
+        let err = SecretStoreError::backend_message(
+            "skipping system secret store access",
+            "system secret store initialization was previously marked as failed",
+        );
+        log::warn!("{err}");
+        return Err(err);
+    }
+
+    let app_name = APP_NAME.read().unwrap().clone();
+    let (service, account) = current_secret_store_names(&app_name);
+    let create_and_store_key = || -> SecretStoreResult<Vec<u8>> {
+        log::info!(
+            "Generating new {} byte key for system secret store (service: {}, account: {})",
+            MASTER_KEY_LEN,
+            service,
+            account
+        );
+        let key = sodiumoxide::randombytes::randombytes(MASTER_KEY_LEN);
+        if let Err(err) = store_secret(&service, &account, &key) {
+            log::error!("Failed to persist generated master key: {err}");
+            return Err(err);
+        }
+        let stored = match load_secret(&service, &account, MASTER_KEY_LEN) {
+            Ok(stored) => stored,
+            Err(err) => {
+                log::warn!("failed to reload master key after storing it: {err}");
+                return Err(err);
+            }
+        };
+        if stored != key {
+            let err = SecretStoreError::invalid(
+                "stored master key verification failed",
+                "reloaded secret does not match the generated key",
+            );
+            log::warn!("stored master key verification failed: {err}");
+            return Err(err);
+        }
+        log::info!("Successfully created and stored new master key in system secret store");
+        Ok(key)
+    };
+    let keybuf = match load_secret(&service, &account, MASTER_KEY_LEN) {
+        Ok(key) => {
+            log::info!(
+                "Loaded existing master key from system secret store (service: {}, account: {})",
+                service,
+                account
+            );
+            key
+        }
+        Err(err) if should_regenerate_master_secret(&err) => {
+            log::warn!(
+                "Stored master key is missing or invalid, regenerating it (service: {}, account: {}, reason: {})",
+                service,
+                account,
+                err
+            );
+            create_and_store_key()?
+        }
+        Err(err) => {
+            log::error!("Failed to load master key: {err}");
+            if should_mark_skip_load(&err) {
+                config::SecretStatus::mark_skip_load();
+            }
+            return Err(err);
+        }
+    };
+    let actual = keybuf.len();
+    Ok(sodiumoxide::crypto::secretbox::Key(
+        keybuf.try_into().map_err(|_| {
+            SecretStoreError::invalid(
+                "stored secret has invalid length",
+                format!("expected {MASTER_KEY_LEN} bytes, got {actual}"),
+            )
+        })?,
+    ))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn load_secret(service: &str, account: &str, expected_len: usize) -> SecretStoreResult<Vec<u8>> {
+    with_expected_len(crate::platform::load_secret(service, account), expected_len)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn store_secret(service: &str, account: &str, secret: &[u8]) -> SecretStoreResult<()> {
+    crate::platform::store_secret(service, account, secret)
+}
+
+fn with_expected_len(
+    secret: SecretStoreResult<Vec<u8>>,
+    expected_len: usize,
+) -> SecretStoreResult<Vec<u8>> {
+    let secret = secret?;
+    if secret.len() == expected_len {
+        Ok(secret)
+    } else {
+        Err(SecretStoreError::invalid(
+            "stored secret has invalid length",
+            format!("expected {expected_len} bytes, got {}", secret.len()),
+        ))
+    }
+}


### PR DESCRIPTION
 ## Summary                                                                                                                                    
  
  Add version 02 user-scoped encryption to ensure user data can only be encrypted/decrypted by the current user on the local machine.           
                 
 ## Implementation Details                                                                                                                     
                                                                                                                                                
  ### 1. Data Format

  - **String format**: `"02" + base64(magic_header + encrypted_data)`
  - **Binary format**: `"02" + magic_header + encrypted_data`
  - **magic_header**: 16-byte fixed header for identifying encrypted data format
  - **encrypted_data**: 
    - Windows: DPAPI CryptProtectData blob.
    - non-Windows: random nonce + secretbox::seal(data, nonce, master_key), where master_key is stored/retrieved from the platform secret backend.

  ### 2. Platform Implementation

  #### Windows
  - Uses DPAPI (`CryptProtectData`/`CryptUnprotectData`) to encrypt data directly
  - No need to maintain keys; system automatically manages user-scoped encryption
  - Chrome's secondary approach (Chrome prioritizes AppBound, falls back to DPAPI-encrypted key stored in Local Storage file, not uses DPAPI to encrypt data directly)

  #### macOS/iOS
  - Stores master key in Keychain (generic password, non-protected mode)
  - Master key is used for secretbox encryption: `random_nonce + secretbox::seal(data, nonce, key)`
  - Encryption flow follows Chrome's implementation
  - **Error handling**:
    - When user clicks deny to reject keychain access (`errSecUserCanceled=-128`), marks `skip_load` status
    - Subsequent launches skip keychain access to avoid repeated authorization prompts
    - Reference: https://support.apple.com/en-lk/guide/keychain-access/kyca1331/mac

  #### Linux
  - **Flatpak environment**: Uses [ashpd](https://docs.rs/ashpd/0.9.2/ashpd/desktop/secret/) library to access Secret Service
  - **Non-Flatpak environment**: Uses [dbus-secret-service](https://docs.rs/dbus-secret-service/latest/) library
  - KDE: Use [secret-service](https://specifications.freedesktop.org/secret-service/latest/ch01.html) rather than kwallet, https://specifications.freedesktop.org/secret-service/latest/ch01.html, https://planet.kde.org/marco-martin-2025-04-14-towards-a-transition-from-kwallet-to-secret-service/
    - **Test results**:
      - ✓ KDE Neon (KDE6): Secret Service available
      - ✗ openSUSE 15.6 (KDE5): Secret Service unavailable, fallback to version 00

  #### Android
  - Sandbox environment not yet implemented, continues using version 00 encryption

## Test

## Tested

- Windows11, WIndows7 x64
- Macos Unsigned
  - Creating a keychain item does not trigger a popup.
  - When another application tries to read the keychain item, a popup appears for the user to choose. 
    - Always Allow: the current application will no longer trigger a popup.
    - Allow: after entering the password in the popup twice, the application will be shown. This applies to each process separately.
    - Deny: no popup will appear permanently, regardless of version. 
- Ubuntu 24.04 Gnome
  - reboot, version update
- flatpak
  - reboot, version update
- Neon KDE
- IOS simulator
- Android

## Not Tested
 - Macos
   - Upgrade between signed applications.
   - A non-UI process triggers Keychain access.
 - Linux
   - headless, other desktop environment
 - All platforms
   - Not logged state
   - A root process triggers user encryption.

## Todo

 - [ ] `--server` process load `LocalConfig.modified_at` will trigger version 02
 - [ ] cm process will read LocalConfig
 - [ ] login screen, headless linux, root user
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform secret storage and management system supporting Windows, macOS, iOS, Linux, and Android
  * Implemented enhanced encryption with platform-specific security variants
  * Added Flatpak support on Linux for secure credential retrieval
  * Improved credential security with versioned encryption scheme for better data protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->