### PR TITLE
feat(terminal): flag, retry output

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -926,6 +926,7 @@ message TerminalOpened {
   uint32 pid = 4;
   string service_id = 5;  // Service ID for persistent sessions
   repeated int32 persistent_sessions = 6; // Used to restore the persistent sessions.
+  bool replay_terminal_output = 7; // Whether the next data response replays buffered terminal output.
 }
 
 message TerminalClosed {


### PR DESCRIPTION
This PR is required by https://github.com/rustdesk/rustdesk/pull/14895


On reconnect, the server may replay recent output.
That replay can include terminal queries like `DSR/DA`; xterm answers them through onOutput as `^[[1;1R^[[2;2R^[[>0;0;0c`, which must not be sent back to the peer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for replaying buffered terminal output during terminal sessions, allowing users to recover previously displayed content when reconnecting to or reopening terminal windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->