### PR TITLE
refact(ipc): trivial changes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -175,7 +175,7 @@ pub fn is_service_ipc_postfix(postfix: &str) -> bool {
 }
 
 // Keep Linux/macOS IPC parent directory rules in one place to avoid drift between
-// `ipc_path()` and Linux-only `ipc_path_for_uid()`.
+// `ipc_path()` and Unix `ipc_path_for_uid()`.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[inline]
 fn ipc_parent_dir_for_uid(uid: u32, postfix: &str) -> String {
@@ -871,7 +871,7 @@ impl Config {
         }
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn ipc_path_for_uid(uid: u32, postfix: &str) -> String {
         let parent = ipc_parent_dir_for_uid(uid, postfix);
         format!("{parent}/ipc{postfix}")
@@ -3523,7 +3523,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn test_uinput_ipc_path_is_shared_across_uids() {
         const ROOT_UID: u32 = 0;
         const USER_UID: u32 = 1000;


### PR DESCRIPTION
Change `ipc_path_for_uid()` to Linux and macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Platform Compatibility**
  * Extended IPC path configuration support to macOS alongside Linux.
  * Expanded test coverage for IPC path sharing across user IDs to macOS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/hbb_common/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->