### PR TITLE
fix(crypt): symmetric crypt compatibility

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -516,12 +516,17 @@ impl Config2 {
 
     fn store(&self) {
         let mut config = self.clone();
+        let stored = Config::load_::<Config2>("2");
         if let Some(mut socks) = config.socks {
+            let stored_password = stored
+                .socks
+                .as_ref()
+                .map(|socks| socks.password.as_str())
+                .unwrap_or_default();
             socks.password =
-                encrypt_str_or_original(&socks.password, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+                keep_encrypted_storage_if_plaintext_unchanged(&socks.password, stored_password);
             config.socks = Some(socks);
         }
-        let stored = Config::load_::<Config2>("2");
         config.unlock_pin =
             keep_encrypted_storage_if_plaintext_unchanged(&config.unlock_pin, &stored.unlock_pin);
         Config::store_(&config, "2");
@@ -716,8 +721,15 @@ impl Config {
         if !config.password.is_empty()
             && decode_permanent_password_h1_from_storage(&config.password).is_none()
         {
-            config.password =
-                encrypt_str_or_original(&config.password, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+            let stored = Config::load_::<Config>("");
+            if stored.password == config.password {
+                config.password = stored.password;
+            } else {
+                config.password = keep_encrypted_storage_if_plaintext_unchanged(
+                    &config.password,
+                    &stored.password,
+                );
+            }
         }
         let (stored_id, encrypted, _) =
             decrypt_str_or_original(&config.enc_id, PASSWORD_ENC_VERSION);

--- a/src/config.rs
+++ b/src/config.rs
@@ -722,14 +722,8 @@ impl Config {
             && decode_permanent_password_h1_from_storage(&config.password).is_none()
         {
             let stored = Config::load_::<Config>("");
-            if stored.password == config.password {
-                config.password = stored.password;
-            } else {
-                config.password = keep_encrypted_storage_if_plaintext_unchanged(
-                    &config.password,
-                    &stored.password,
-                );
-            }
+            config.password =
+                keep_encrypted_storage_if_plaintext_unchanged(&config.password, &stored.password);
         }
         let (stored_id, encrypted, _) =
             decrypt_str_or_original(&config.enc_id, PASSWORD_ENC_VERSION);


### PR DESCRIPTION

Retain the local permanent and SOCKS passwords if unchanged.

## Testing

Switching between 1.4.6 and the current version does not alter the local permanent or SOCKS passwords unless manually changed.

## Notes

Changes to the local permanent password, RDP password, OS username, or OS password only affect the control/local side. 

Compatibility for this does not need to be over-engineered.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Configuration saves now preserve existing encrypted credentials when the provided plaintext is unchanged, preventing unnecessary re-encryption.
  * Applies to both SOCKS5 and permanent password storage, reducing work during saves while maintaining security and existing ciphertext where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->