### PR TITLE
fix: bytes codex, avoid unlimit reserve()

### DIFF
--- a/src/bytes_codec.rs
+++ b/src/bytes_codec.rs
@@ -2,6 +2,9 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
+// Bound speculative allocation from untrusted frame headers.
+const MAX_PREALLOCATED_PAYLOAD_LEN: usize = 256 * 1024;
+
 #[derive(Debug, Clone, Copy)]
 pub struct BytesCodec {
     state: DecodeState,
@@ -61,7 +64,12 @@ impl BytesCodec {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "Too big packet"));
         }
         src.advance(head_len);
-        src.reserve(n);
+        // Do not reserve the full header-declared length: a peer can advertise a huge
+        // frame and force excessive allocation before sending the payload.
+        src.reserve(
+            n.saturating_sub(src.len())
+                .min(MAX_PREALLOCATED_PAYLOAD_LEN),
+        );
         Ok(Some(n))
     }
 
@@ -276,5 +284,18 @@ mod tests {
         } else {
             panic!();
         }
+    }
+
+    #[test]
+    fn decode_large_frame_header_caps_preallocation() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let n = 0x3FFFFFFFusize;
+        const MAX_REASONABLE_CAPACITY: usize = MAX_PREALLOCATED_PAYLOAD_LEN * 4;
+
+        buf.put_u32_le((n << 2) as u32 | 0x3);
+
+        assert!(matches!(codec.decode(&mut buf), Ok(None)));
+        assert!(buf.capacity() <= MAX_REASONABLE_CAPACITY);
     }
 }


### PR DESCRIPTION
Bound speculative allocation from untrusted frame headers, max 256 KB.

The file transfer block is 128 KB before compression.

https://github.com/rustdesk/hbb_common/blob/e50ac3cd4897fa6c6ed545189adb2170c34df636/src/fs.rs#L952


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed excessive memory reservation when decoding frame headers with large advertised payload sizes, preventing potential memory exhaustion issues.

* **Tests**
  * Added test coverage to validate proper handling of frame headers with extreme size values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->