### PR TITLE
Improve WebSocket redirect error message

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -168,7 +168,15 @@ impl WsFramedStream {
                         url,
                         e
                     );
-                    bail!(e)
+                    if let tungstenite::Error::Http(response) = &e {
+                        if response.status().is_redirection() {
+                            bail!(
+                                "WebSocket connection failed ({}). The server may not support WebSocket.",
+                                e
+                            )
+                        }
+                    }
+                    bail!("WebSocket error: {}", e)
                 }
             },
         }


### PR DESCRIPTION
Tested with public server.

 | Before | After |
| ---------|---------|
| <img width="381" height="165" alt="before" src="https://github.com/user-attachments/assets/7fea9c17-292e-4a9f-bab7-4f806636d818" /> | <img width="554" height="186" alt="after" src="https://github.com/user-attachments/assets/1b38d0aa-704d-4779-a491-90fcbfb5bbb2" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for WebSocket connection failures, providing clearer feedback when servers may not support WebSocket or when other connection errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->