### PR TITLE
Add controlled context for controller audit attribution

### DIFF
--- a/protos/rendezvous.proto
+++ b/protos/rendezvous.proto
@@ -49,6 +49,10 @@ message ControlPermissions {
   uint64 permissions = 1;
 }
 
+message ControlledContext {
+  string conn_audit_ref = 1;
+}
+
 message PunchHole {
   bytes socket_addr = 1;
   string relay_server = 2;
@@ -58,6 +62,7 @@ message PunchHole {
   int32 upnp_port = 6;
   bytes socket_addr_v6 = 7;
   ControlPermissions control_permissions = 8;
+  ControlledContext controlled_context = 9;
 }
 
 message TestNatRequest {
@@ -146,6 +151,7 @@ message RequestRelay {
   ConnType conn_type = 7;
   string token = 8;
   ControlPermissions control_permissions = 9;
+  ControlledContext controlled_context = 10;
 }
 
 message RelayResponse {
@@ -174,6 +180,7 @@ message FetchLocalAddr {
   string relay_server = 2;
   bytes socket_addr_v6 = 3;
   ControlPermissions control_permissions = 4;
+  ControlledContext controlled_context = 5;
 }
 
 message LocalAddr {


### PR DESCRIPTION
Add `ControlledContext` to rendezvous messages so the server can pass a controller-user audit token to the controlled client.
 
The controlled client returns the token when posting audit logs, allowing the server to associate those logs with the controller user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection and relay requests now include additional context data to improve handling of controlled connections.
  * Local address lookup requests can now carry the same connection context information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->