### PR TITLE
Add ControlledContext for controller audit attribution

### DIFF
--- a/protos/rendezvous.proto
+++ b/protos/rendezvous.proto
@@ -49,6 +49,10 @@ message ControlPermissions {
   uint64 permissions = 1;
 }
 
+message ControlledContext {
+  string conn_audit_token = 1;
+}
+
 message PunchHole {
   bytes socket_addr = 1;
   string relay_server = 2;
@@ -58,6 +62,7 @@ message PunchHole {
   int32 upnp_port = 6;
   bytes socket_addr_v6 = 7;
   ControlPermissions control_permissions = 8;
+  ControlledContext controlled_context = 9;
 }
 
 message TestNatRequest {
@@ -146,6 +151,7 @@ message RequestRelay {
   ConnType conn_type = 7;
   string token = 8;
   ControlPermissions control_permissions = 9;
+  ControlledContext controlled_context = 10;
 }
 
 message RelayResponse {
@@ -174,6 +180,7 @@ message FetchLocalAddr {
   string relay_server = 2;
   bytes socket_addr_v6 = 3;
   ControlPermissions control_permissions = 4;
+  ControlledContext controlled_context = 5;
 }
 
 message LocalAddr {


### PR DESCRIPTION
## Summary

Re-opens the intent of #559 (closed unmerged).

Adds `ControlledContext { conn_audit_token }` to rendezvous messages (`PunchHole`, `RequestRelay`, `FetchLocalAddr`) so the rendezvous/API server can pass a short-lived controller-user token to the controlled client. The controlled client returns the token when posting audit logs, allowing the server to associate those logs with the controller user.

## Compatibility

- New field numbers only (9/10/5) — old clients/servers ignore unknown fields.
- Required by the rustdesk controller-audit follow-up (split from rustdesk/rustdesk#15407).

## Related PRs

1. **This PR** (hbb_common) — proto/types only, must land first
2. [rustdesk part 1](https://github.com/rustdesk/rustdesk/compare/master...harsh-98:rustdesk:pr-15407-part1-connection-meta-audit-conn-id) — no hbb_common dependency, can merge independently
3. rustdesk part 2 — controller audit token (blocked on this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new connection context to selected network-related requests, allowing them to carry additional audit information.
  * Updated hole punching, relay requests, and local address fetch requests to support the new context field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->