### PR TITLE
fix: insecure conn, fail-close

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2963,6 +2963,7 @@ pub mod keys {
     pub const OPTION_FILE_TRANSFER_MAX_FILES: &str = "file-transfer-max-files";
     pub const OPTION_DISABLE_UDP: &str = "disable-udp";
     pub const OPTION_ALLOW_INSECURE_TLS_FALLBACK: &str = "allow-insecure-tls-fallback";
+    pub const OPTION_ALLOW_INSECURE_SESSION_FALLBACK: &str = "allow-insecure-session-fallback";
     pub const OPTION_SHOW_VIRTUAL_MOUSE: &str = "show-virtual-mouse";
     // joystick is the virtual mouse.
     // So `OPTION_SHOW_VIRTUAL_MOUSE` should also be set if `OPTION_SHOW_VIRTUAL_JOYSTICK` is set.
@@ -3181,6 +3182,7 @@ pub mod keys {
         OPTION_ICE_SERVERS,
         OPTION_DISABLE_UDP,
         OPTION_ALLOW_INSECURE_TLS_FALLBACK,
+        OPTION_ALLOW_INSECURE_SESSION_FALLBACK,
         OPTION_KEEP_AWAKE_DURING_INCOMING_SESSIONS,
         OPTION_ALLOW_AUTO_UPDATE,
     ];


### PR DESCRIPTION
Add an option to allow insecure connections for legacy clients that don't support end-to-end encryption.

Both sides need to enable this option to allow insecure connections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option, `allow-insecure-session-fallback`, for environments that need to recognize and store this setting.
  * The option is now included in the list of supported settings values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->