### PR TITLE
fix(android): persist key_pair synchronously to stabilize peer ID

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1129,11 +1129,10 @@ impl Config {
             let (pk, sk) = sign::gen_keypair();
             let key_pair = (sk.0.to_vec(), pk.0.into());
             config.key_pair = key_pair.clone();
-            std::thread::spawn(|| {
-                let mut config = CONFIG.write().unwrap();
-                config.key_pair = key_pair;
-                config.store();
-            });
+            // 同步落盘(原 spawn T2 异步:进程在 T2 跑完前被杀 → key_pair 没落盘 →
+            // 下次重启 enc_id 解密失败 → gen_id 随机 → peer ID 每次变)。
+            // store_ 是纯文件写不碰 CONFIG 锁,在 Config::load 内调用安全。
+            Config::store_(&config, "");
         }
         *lock = Some(config.key_pair.clone());
         config.key_pair


### PR DESCRIPTION
get_key_pair 原用 std::thread::spawn 异步落盘 key_pair,进程在 T2 跑完前被杀则 key_pair 丢失,下次重启 enc_id 解密失败 → gen_id 随机 → peer ID 每次变。改同步 store_ 落盘。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New key pairs are now saved immediately after creation, reducing the risk of losing them if the app exits quickly.
  * Improved reliability around configuration updates by avoiding delayed background saving.
* **Documentation**
  * Added clearer in-code guidance for the saving and locking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->