### PR TITLE
feat: support grayscale mode to save bandwidth (partial)

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -20,6 +20,7 @@ message YUV {
 enum Chroma {
   I420 = 0;
   I444 = 1;
+  I400 = 2;
 }
 
 message VideoFrame {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2380,6 +2380,18 @@ impl UserDefaultConfig {
             keys::OPTION_ENABLE_FILE_COPY_PASTE => self.get_string(key, "Y", vec!["", "N"]),
             keys::OPTION_EDGE_SCROLL_EDGE_THICKNESS => self.get_num_string(key, 100, 20, 150),
             keys::OPTION_TRACKPAD_SPEED => self.get_num_string(key, 100, 10, 1000),
+            keys::OPTION_COLOR_MODE => {
+                let v = self.get_string(key, "i420", vec!["i444", "i400"]);
+                if v == "i420" {
+                    if self.options.get(keys::OPTION_I444) == Some(&"Y".to_string()) {
+                        "i444".to_string()
+                    } else {
+                        "i420".to_string()
+                    }
+                } else {
+                    v
+                }
+            }
             _ => self
                 .get_after(key)
                 .map(|v| v.to_string())
@@ -2867,6 +2879,8 @@ pub mod keys {
     pub const OPTION_PRIVACY_MODE: &str = "privacy_mode";
     pub const OPTION_TOUCH_MODE: &str = "touch-mode";
     pub const OPTION_I444: &str = "i444";
+    // i444 is for backward compatibility
+    pub const OPTION_COLOR_MODE: &str = "color-mode";
     pub const OPTION_REVERSE_MOUSE_WHEEL: &str = "reverse_mouse_wheel";
     pub const OPTION_SWAP_LEFT_RIGHT_MOUSE: &str = "swap-left-right-mouse";
     pub const OPTION_DISPLAYS_AS_INDIVIDUAL_WINDOWS: &str = "displays_as_individual_windows";


### PR DESCRIPTION
Associated with:

- feat: support grayscale mode to save bandwidth (partial)
 https://github.com/rustdesk/rustdesk/pull/15527
- Working with extremely low data rates https://github.com/rustdesk/rustdesk/discussions/1397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new color mode option in user defaults.
  * Improved compatibility so some existing color settings may now map to a higher-fidelity mode when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->