### PR TITLE
feat: merge custom rendezvous server with builtin servers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -938,9 +938,9 @@ impl Config {
         if !s.is_empty() {
             return vec![s];
         }
-        let s = Self::get_option("custom-rendezvous-server");
-        if !s.is_empty() {
-            return vec![s];
+        let custom = Self::get_option("custom-rendezvous-server");
+        if !custom.is_empty() {
+            return Self::merge_with_builtin_servers(vec![custom]);
         }
         let s = PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
         if !s.is_empty() {
@@ -958,6 +958,16 @@ impl Config {
             }
         }
         return RENDEZVOUS_SERVERS.iter().map(|x| x.to_string()).collect();
+    }
+
+    fn merge_with_builtin_servers(mut servers: Vec<String>) -> Vec<String> {
+        let builtin: Vec<String> = RENDEZVOUS_SERVERS.iter().map(|x| x.to_string()).collect();
+        for s in builtin {
+            if !servers.contains(&s) {
+                servers.push(s);
+            }
+        }
+        servers
     }
 
     pub fn reset_online() {


### PR DESCRIPTION
## Summary

When a `custom-rendezvous-server` is configured via Settings, the current `get_rendezvous_servers()` returns only the custom server, discarding the hardcoded `RENDEZVOUS_SERVERS`. This prevents the client from being online on both servers simultaneously.

## Changes

- Modified `Config::get_rendezvous_servers()` to call a new `merge_with_builtin_servers()` helper when a custom server is configured, which appends the hardcoded `RENDEZVOUS_SERVERS` (deduplicated) to the returned list.
- This enables the client to register on both the user-configured server and the builtin public servers at the same time.

## Related

This PR is part of the dual-server-online feature. The companion PR in the main rustdesk repo modifies `RendezvousMediator` to handle multiple simultaneous server connections properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom rendezvous server settings now retain access to built-in fallback servers.
  * Duplicate server entries are automatically removed when combining custom and built-in servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->