### PR TITLE
feat(config): add recording visibility and service save path options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2924,6 +2924,9 @@ pub mod keys {
     pub const OPTION_ALLOW_ONLY_CONN_WINDOW_OPEN: &str = "allow-only-conn-window-open";
     pub const OPTION_ALLOW_AUTO_RECORD_INCOMING: &str = "allow-auto-record-incoming";
     pub const OPTION_ALLOW_AUTO_RECORD_OUTGOING: &str = "allow-auto-record-outgoing";
+    pub const OPTION_HIDE_RECORDING_BUTTON: &str = "hide-recording-button";
+    pub const OPTION_WINDOWS_SERVICE_VIDEO_SAVE_DIRECTORY: &str =
+        "windows-service-video-save-directory";
     pub const OPTION_VIDEO_SAVE_DIRECTORY: &str = "video-save-directory";
     pub const OPTION_ENABLE_ABR: &str = "enable-abr";
     pub const OPTION_ALLOW_REMOVE_WALLPAPER: &str = "allow-remove-wallpaper";
@@ -3120,6 +3123,7 @@ pub mod keys {
         OPTION_PRE_ELEVATE_SERVICE,
         OPTION_ALLOW_REMOTE_CM_MODIFICATION,
         OPTION_ALLOW_AUTO_RECORD_OUTGOING,
+        OPTION_HIDE_RECORDING_BUTTON,
         OPTION_VIDEO_SAVE_DIRECTORY,
         OPTION_ENABLE_UDP_PUNCH,
         OPTION_ENABLE_IPV6_PUNCH,
@@ -3157,6 +3161,7 @@ pub mod keys {
         OPTION_AUTO_DISCONNECT_TIMEOUT,
         OPTION_ALLOW_ONLY_CONN_WINDOW_OPEN,
         OPTION_ALLOW_AUTO_RECORD_INCOMING,
+        OPTION_WINDOWS_SERVICE_VIDEO_SAVE_DIRECTORY,
         OPTION_ENABLE_ABR,
         OPTION_ALLOW_REMOVE_WALLPAPER,
         OPTION_ALLOW_ALWAYS_SOFTWARE_RENDER,


### PR DESCRIPTION
- add `hide-recording-button` to local settings
- add `windows-service-video-save-directory` to service settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to hide the recording button.
  * Added an option to configure the video save directory for the Windows service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->