### PR TITLE
feat(rendezvous): add UDP punch negotiation fields

### DIFF
--- a/protos/rendezvous.proto
+++ b/protos/rendezvous.proto
@@ -64,16 +64,19 @@ message PunchHole {
   bytes socket_addr_v6 = 7;
   ControlPermissions control_permissions = 8;
   ControlledContext controlled_context = 9;
+  bytes udp_punch_token = 10;
 }
 
 message TestNatRequest {
   int32 serial = 1;
+  bytes nonce = 2;
 }
 
 // per my test, uint/int has no difference in encoding, int not good for negative, use sint for negative
 message TestNatResponse {
   int32 port = 1; 
   ConfigUpdate cu = 2; // for mobile
+  bytes nonce = 3;
 }
 
 enum NatType {
@@ -90,6 +93,7 @@ message PunchHoleSent {
   string version = 5;
   int32 upnp_port = 6;
   bytes socket_addr_v6 = 7;
+  bytes udp_punch_token = 8;
 }
 
 message RegisterPk {
@@ -98,6 +102,7 @@ message RegisterPk {
   bytes pk = 3;
   string old_id = 4;
   bool no_register_device = 5;
+  bool udp_punch_token_supported = 6;
 }
 
 message RegisterPkResponse {


### PR DESCRIPTION
## Summary

Adds wire-compatible rendezvous protocol fields required for authenticated UDP hole-punch negotiation:

- `TestNatRequest.nonce`
- `TestNatResponse.nonce`
- `PunchHole.udp_punch_token`
- `PunchHoleSent.udp_punch_token`
- `RegisterPk.udp_punch_token_supported`

## Motivation

The existing UDP candidate path does not have a server-verified completion signal.
These fields allow a rendezvous server to:

- bind UDP completion to a short-lived, single-use token;
- verify NAT test replies belong to the active request;
- negotiate the feature only with clients that explicitly support it.

All fields are additive protobuf fields. Older clients and servers ignore them and
continue using the existing TCP/relay flow.

## Follow-up

Client and hbbs support will be submitted separately after this protocol change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for UDP punch tokens during connection setup.
  * Added nonce exchange for NAT connectivity testing.
  * Added capability signaling for UDP punch token support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->