### PR TITLE
add texture-render-health internal option key

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2889,6 +2889,9 @@ pub mod keys {
     pub const OPTION_ENABLE_OPEN_NEW_CONNECTIONS_IN_TABS: &str =
         "enable-open-new-connections-in-tabs";
     pub const OPTION_TEXTURE_RENDER: &str = "use-texture-render";
+    // Internal health record written by the texture-render watchdog/probe;
+    // "failed-*" flips the texture-render default to opt-in on this machine.
+    pub const OPTION_TEXTURE_RENDER_HEALTH: &str = "texture-render-health";
     pub const OPTION_ALLOW_D3D_RENDER: &str = "allow-d3d-render";
     pub const OPTION_ENABLE_CHECK_UPDATE: &str = "enable-check-update";
     pub const OPTION_ALLOW_AUTO_UPDATE: &str = "allow-auto-update";


### PR DESCRIPTION
Written by the texture-render watchdog / startup probe in the main repo; a failed record forces texture rendering off until it is cleared (probe pass or an explicit toggle of use-texture-render).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public configuration option for monitoring texture-rendering health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->