### PR TITLE
refact(logs): keep logs, 31 -> 90 files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@ pub fn init_log(_is_async: bool, _name: &str) -> Option<flexi_logger::LoggerHand
                     .rotate(
                         Criterion::Age(Age::Day),
                         Naming::Timestamps,
-                        Cleanup::KeepLogFiles(31),
+                        Cleanup::KeepLogFiles(90),
                     )
                     .start()
                     .ok();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Log files are now retained for 90 days instead of 31 days, providing access to a longer history of application activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->