### PR TITLE
fix(linux): read output positions from xdg-output on wlroots

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -467,7 +467,11 @@ fn collect_wayland_displays(conn: &Connection) -> ResultType<Vec<WaylandDisplayI
         if let Some(output_data) = output.data::<OutputData>() {
             output_data.with_output_info(|info| {
                 if let Some(mode) = info.modes.iter().find(|m| m.current) {
-                    let (x, y) = info.location;
+                    // wlroots compositors leave wl_output.geometry at (0, 0) for every output and
+                    // publish the real layout only through xdg-output, so taking `location` there
+                    // stacks the whole desktop on the origin. Mutter fills both, so this stays a
+                    // no-op on GNOME.
+                    let (x, y) = info.logical_position.unwrap_or(info.location);
                     let (width, height) = mode.dimensions;
                     let refresh_rate = mode.refresh_rate;
                     let name = info.name.clone().unwrap_or_default();


### PR DESCRIPTION
on wlroots compositors every `wl_output` reports its position as (0, 0); the real layout only shows up in `xdg-output`. we read the position from `wl_output`, so on those compositors the whole desktop collapses onto the origin and the desktop rect ends up being the widest single output instead of the union.

measured on sway 1.11, amdgpu, two outputs side by side (`DP-6` 1920x1080 at +0+0, `eDP-1` 1440x900 at +1920+0, so a 3360x1080 desktop):

```
wl_output   DP-6   x: 0, y: 0        eDP-1   x: 0, y: 0
xdg-output  DP-6   logical_x: 0      eDP-1   logical_x: 1920
```

and with the same probe binary built before and after the change, on that machine:

```
before   eDP-1 at (0, 0)      desktop rect: (0, 1920) x (0, 1080)
after    eDP-1 at (1920, 0)   desktop rect: (0, 3360) x (0, 1080)
```

the practical effect on the linux host: `update_mouse_resolution` gets that rect, so the uinput absolute range came out 1920x1080 on a 3360-wide desktop. i confirmed the device itself with evtest: `ABS_X Max 1920`. the compositor stretches that range over the whole layout, so every injected coordinate lands scaled — measured separately on mutter, where a device with range 0..1280 on a 6400-wide desktop put an injected 640 at 3196 — and the shared output is also advertised at the origin instead of at its real x. i did not measure landing positions under sway itself, only the range.

this is adjacent to rustdesk/rustdesk#15731 but not the same defect: both reporters there log a range that already covers their full root, so their positions are not collapsed.

`logical_size` was already being read from xdg-output here, only the position was not.

mutter fills in `wl_output` as well, so gnome is unchanged. checked with the same probe on gnome 46 with a 6400x2160 desktop: the rect is 6400x2160 before and after.
