### PR TITLE
Port forward mux

### DIFF
--- a/protos/message.proto
+++ b/protos/message.proto
@@ -55,6 +55,7 @@ message DisplayInfo {
 message PortForward {
   string host = 1;
   int32 port = 2;
+  bool multiplex = 3;
 }
 
 message FileTransfer {
@@ -104,6 +105,7 @@ message ChatMessage { string text = 1; }
 message Features {
   bool privacy_mode = 1;
   bool terminal = 2;
+  bool port_forward_mux = 3;
 }
 
 message CodecAbility {
@@ -949,6 +951,46 @@ message TerminalResponse {
   }
 }
 
+message PortForwardOpen {
+  int32 channel_id = 1;
+  string host = 2;
+  int32 port = 3;
+  uint32 window = 4;
+}
+
+message PortForwardOpened {
+  int32 channel_id = 1;
+  bool success = 2;
+  string message = 3;
+  uint32 window = 4;
+}
+
+message PortForwardData {
+  int32 channel_id = 1;
+  bytes data = 2;
+}
+
+message PortForwardClose {
+  int32 channel_id = 1;
+}
+
+message PortForwardWindowUpdate {
+  int32 channel_id = 1;
+  uint32 add = 2;
+}
+
+// One symmetric message for both directions. `open` only travels controller -> controlled,
+// `opened` only controlled -> controller; a frame in the wrong direction is ignored.
+message PortForwardChannel {
+  oneof union {
+    PortForwardOpen open = 1;
+    PortForwardOpened opened = 2;
+    PortForwardData data = 3;
+    PortForwardClose close = 4;
+    PortForwardWindowUpdate window_update = 5;
+  }
+}
+
 message Message {
   oneof union {
     SignedId signed_id = 3;
@@ -981,5 +1023,6 @@ message Message {
     ScreenshotResponse screenshot_response= 30;
     TerminalAction terminal_action = 31;
     TerminalResponse terminal_response = 32;
+    PortForwardChannel port_forward_channel = 33;
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2995,6 +2995,7 @@ pub mod keys {
     // Connection punch-through options
     pub const OPTION_ENABLE_UDP_PUNCH: &str = "enable-udp-punch";
     pub const OPTION_ENABLE_IPV6_PUNCH: &str = "enable-ipv6-punch";
+    pub const OPTION_ENABLE_PORT_FORWARD_MUX: &str = "enable-port-forward-mux";
     pub const OPTION_HIDE_USERNAME_ON_CARD: &str = "hide-username-on-card";
     pub const OPTION_HIDE_HELP_CARDS: &str = "hide-help-cards";
     pub const OPTION_DEFAULT_CONNECT_PASSWORD: &str = "default-connect-password";
@@ -3126,6 +3127,7 @@ pub mod keys {
         OPTION_VIDEO_SAVE_DIRECTORY,
         OPTION_ENABLE_UDP_PUNCH,
         OPTION_ENABLE_IPV6_PUNCH,
+        OPTION_ENABLE_PORT_FORWARD_MUX,
         OPTION_TOUCH_MODE,
         OPTION_SHOW_VIRTUAL_MOUSE,
         OPTION_SHOW_VIRTUAL_JOYSTICK,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2992,7 +2992,7 @@ pub mod keys {
     pub const OPTION_ALLOW_COMMAND_LINE_SETTINGS_WHEN_SETTINGS_DISABLED: &str =
         "allow-command-line-settings-when-settings-disabled";
 
-    // Connection punch-through options
+    // Connection punch-through / port-forward options
     pub const OPTION_ENABLE_UDP_PUNCH: &str = "enable-udp-punch";
     pub const OPTION_ENABLE_IPV6_PUNCH: &str = "enable-ipv6-punch";
     pub const OPTION_ENABLE_PORT_FORWARD_MUX: &str = "enable-port-forward-mux";


### PR DESCRIPTION
## What this adds

Wire and config support for rustdesk/rustdesk#NNN, which multiplexes every local connection of a port-forward window over one authenticated peer connection.

### `protos/message.proto`

- `PortForwardChannel`, `Message.union` tag 33: one symmetric message carrying `open` / `opened` / `data` / `close` / `window_update`. `open` travels controller → controlled only and `opened` the other way; a frame in the wrong direction is ignored by the receiver.
- `PortForward.multiplex` (tag 3): the controller asks for the tunnel in its login request. An old controlled side ignores the field and serves the raw pipe as today.
- `Features.port_forward_mux` (tag 3): the controlled side answers in `PeerInfo`, so the controller knows at login, with no extra round trip, whether the connection is a tunnel or a raw pipe.

`open` and `opened` carry the sender's receive window in bytes; `window_update` adds to it. The two flow-control constants that are part of the protocol (`INITIAL_WINDOW` = 64 KiB, `MIN_FRAME_CHARGE` = 64 B) are fixed and live in the rustdesk crate.

### `src/config.rs`

`enable-port-forward-mux`, a `KEYS_LOCAL_SETTINGS` entry read on the controlling side only. The `enable-` prefix makes an unset value read as on; turning it off means the controller sends no `multiplex`, so both sides take the legacy path with no negotiation.

## Compatibility

Purely additive: new messages, new fields with fresh tags, one new setting key. No existing field, tag or key changes.

Merge before rustdesk/rustdesk#NNN; that branch's submodule pointer refers to this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional multiplexing for port-forward connections, allowing multiple channels over a single connection.
  * Added support for opening, acknowledging, transferring data through, closing, and updating flow-control windows for port-forward channels.
  * Added a local configuration option to enable port-forward multiplexing.
  * Added feature negotiation so compatible endpoints can advertise port-forward multiplexing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->